### PR TITLE
[#52] 기존 BinOp로직을 binop_parser.py에 분리

### DIFF
--- a/app/analysis/generator/parser/binop_parser.py
+++ b/app/analysis/generator/parser/binop_parser.py
@@ -15,9 +15,9 @@ class BinopParser:
         self.elem_manager = elem_manager
 
     def parse(self):
-        value = self.__calculate_value(self.node)
-        expressions = self.__create_expressions(ast.unparse(self.node), value)
-        return Binop(value, expressions)
+        result = self.__calculate_value(self.node)
+        expressions = self.__create_expressions(ast.unparse(self.node), result)
+        return Binop(result, expressions)
 
     # 연산식을 따라가면서 계산해 결과를 반환
     def __calculate_value(self, node):

--- a/app/analysis/generator/parser/binop_parser.py
+++ b/app/analysis/generator/parser/binop_parser.py
@@ -1,0 +1,74 @@
+import ast
+import re
+from dataclasses import dataclass
+
+from app.analysis.element_manager import CodeElementManager
+from app.analysis.generator.parser.constant_parser import ConstantParser
+from app.analysis.generator.parser.name_parser import NameParser
+
+
+class BinopParser:
+
+    def __init__(self, node: ast.BinOp, elem_manager: CodeElementManager):
+        self.node = node
+        self.elem_manager = elem_manager
+
+    def parse(self):
+        value = self.__calculate_value(self.node)
+        expressions = self.__create_expressions(ast.unparse(self.node), value)
+        return BinOp(value, expressions)
+
+    # 연산식을 따라가면서 계산해 결과를 반환
+    def __calculate_value(self, node):
+        if isinstance(node, ast.BinOp):
+            left = self.__calculate_value(node.left)
+            right = self.__calculate_value(node.right)
+            if isinstance(node.op, ast.Add):
+                value = left + right
+            elif isinstance(node.op, ast.Sub):
+                value = left - right
+            elif isinstance(node.op, ast.Mult):
+                value = left * right
+            elif isinstance(node.op, ast.Div):
+                value = left / right
+            else:
+                raise NotImplementedError(f"Unsupported operator: {type(node.op)}")
+            return value
+        elif isinstance(node, ast.Name):
+            name = NameParser(node, self.elem_manager).parse()
+            return name.value
+        elif isinstance(node, ast.Constant):
+            constant = ConstantParser(node).parse()
+            return constant.value
+        else:
+            raise NotImplementedError(f"Unsupported node type: {type(node)}")
+
+    def __create_expressions(self, expr, result):
+        # 초기 계산식 저장
+        expr_results = [expr]
+        pattern = r'\b[a-zA-Z_]\w*\b'
+        var_names = set(re.findall(pattern, expr))
+
+        # 변수들을 값으로 대체
+        for var in var_names:
+            value = self.elem_manager.get_variable_value(var)
+            expr = self.__replace_variable(expression=expr, variable=var, key=value)
+
+        if len(var_names) != 0:
+            expr_results.append(expr)
+
+        # 마지막 계산 결과 저장
+        expr_results.append(result)
+        return expr_results
+
+    @staticmethod
+    def __replace_variable(expression, variable, key):
+        pattern = rf'\b{variable}\b'
+        replaced_expression = re.sub(pattern, str(key), expression)
+        return replaced_expression
+
+
+@dataclass
+class BinOp:
+    value: int
+    expressions: list

--- a/app/analysis/generator/parser/binop_parser.py
+++ b/app/analysis/generator/parser/binop_parser.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from app.analysis.element_manager import CodeElementManager
 from app.analysis.generator.parser.constant_parser import ConstantParser
 from app.analysis.generator.parser.name_parser import NameParser
+from app.analysis.util.util import replace_variable
 
 
 class BinopParser:
@@ -52,7 +53,7 @@ class BinopParser:
         # 변수들을 값으로 대체
         for var in var_names:
             value = self.elem_manager.get_variable_value(var)
-            expr = self.__replace_variable(expression=expr, variable=var, key=value)
+            expr = replace_variable(expression=expr, variable=var, key=value)
 
         if len(var_names) != 0:
             expr_results.append(expr)
@@ -60,12 +61,6 @@ class BinopParser:
         # 마지막 계산 결과 저장
         expr_results.append(result)
         return expr_results
-
-    @staticmethod
-    def __replace_variable(expression, variable, key):
-        pattern = rf'\b{variable}\b'
-        replaced_expression = re.sub(pattern, str(key), expression)
-        return replaced_expression
 
 
 @dataclass

--- a/app/analysis/generator/parser/binop_parser.py
+++ b/app/analysis/generator/parser/binop_parser.py
@@ -17,7 +17,7 @@ class BinopParser:
     def parse(self):
         value = self.__calculate_value(self.node)
         expressions = self.__create_expressions(ast.unparse(self.node), value)
-        return BinOp(value, expressions)
+        return Binop(value, expressions)
 
     # 연산식을 따라가면서 계산해 결과를 반환
     def __calculate_value(self, node):
@@ -64,6 +64,6 @@ class BinopParser:
 
 
 @dataclass
-class BinOp:
+class Binop:
     value: int
     expressions: list

--- a/app/analysis/generator/parser/binop_parser.py
+++ b/app/analysis/generator/parser/binop_parser.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from app.analysis.element_manager import CodeElementManager
 from app.analysis.generator.parser.constant_parser import ConstantParser
 from app.analysis.generator.parser.name_parser import NameParser
-from app.analysis.util.util import replace_variable
+from app.analysis.util.util import replace_word
 
 
 class BinopParser:
@@ -53,7 +53,7 @@ class BinopParser:
         # 변수들을 값으로 대체
         for var in var_names:
             value = self.elem_manager.get_variable_value(var)
-            expr = replace_variable(expression=expr, variable=var, key=value)
+            expr = replace_word(expression=expr, original_word=var, new_word=value)
 
         if len(var_names) != 0:
             expr_results.append(expr)

--- a/app/analysis/util/util.py
+++ b/app/analysis/util/util.py
@@ -1,7 +1,7 @@
 import re
 
 
-def replace_variable(expression, variable, key):
-    pattern = rf'\b{variable}\b'
-    replaced_expression = re.sub(pattern, str(key), expression)
+def replace_word(expression, original_word, new_word):
+    pattern = rf'\b{original_word}\b'
+    replaced_expression = re.sub(pattern, str(new_word), expression)
     return replaced_expression

--- a/app/analysis/util/util.py
+++ b/app/analysis/util/util.py
@@ -1,0 +1,7 @@
+import re
+
+
+def replace_variable(expression, variable, key):
+    pattern = rf'\b{variable}\b'
+    replaced_expression = re.sub(pattern, str(key), expression)
+    return replaced_expression


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #52 

## 📝 작업 내용

- binOp를 위해 사용하던 함수들을 BinopParser

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- BinopParser의 결과로 나오는 Binop 객체에 들어갈 속성이 이게 다가 맞을까요?
- __create_expressions()함수에서 하는 일을 표현식을 만들어주는 객체를 따로 만드는게 좋을까요? 의견 주시면 반영하겠습니다.