### PR TITLE
[#61]refactor: 기존 print블록 로직을 Expr_generator.py, call_parser.py로 분리 #61

### DIFF
--- a/app/analysis/code_analyzer.py
+++ b/app/analysis/code_analyzer.py
@@ -1,6 +1,7 @@
 import ast
 
 from app.analysis.element_manager import CodeElementManager
+from app.analysis.generator.expr_generator import ExprGenerator
 from app.analysis.parser1 import assign_parse, for_parse
 from app.analysis.step_manager import StepManager
 
@@ -29,3 +30,6 @@ class CodeAnalyzer:
         elif isinstance(node, ast.For):
             steps = for_parse(node, self.elem_manager)
             self.step_manager.add_steps(steps)
+
+        elif isinstance(node, ast.Expr):
+            ExprGenerator(node, self.elem_manager).generate()

--- a/app/analysis/code_analyzer.py
+++ b/app/analysis/code_analyzer.py
@@ -31,4 +31,5 @@ class CodeAnalyzer:
             self.step_manager.add_steps(steps)
 
         elif isinstance(node, ast.Expr):
-            ExprGenerator(node, self.elem_manager).generate()
+            steps = ExprGenerator(node, self.elem_manager).generate()
+            self.step_manager.add_steps(steps)

--- a/app/analysis/code_analyzer.py
+++ b/app/analysis/code_analyzer.py
@@ -17,7 +17,6 @@ class CodeAnalyzer:
         print(ast.dump(node, indent=4))
 
     def visualize_code(self, parsed_ast):
-
         for node in parsed_ast.body:
             self.parse_node(node)
         return self.step_manager.get_steps()

--- a/app/analysis/generator/expr_generator.py
+++ b/app/analysis/generator/expr_generator.py
@@ -2,7 +2,9 @@
 import ast
 
 from app.analysis.element_manager import CodeElementManager
-from app.analysis.generator.parser.call_parser import CallParser
+from app.analysis.generator.parser.call_parser import CallParser, Print
+from app.analysis.highlight import expressions_highlight_indices
+from app.analysis.models import PrintViz
 
 
 class ExprGenerator:
@@ -18,11 +20,54 @@ class ExprGenerator:
             return self
         elif isinstance(self.value, ast.BinOp):
             return self
+        # 함수
         elif isinstance(self.value, ast.Call):
-            CallParser(self.value, self.elem_manager).parse()
-            return self
+            call_parser = CallParser(self.value, self.elem_manager)
+            return self.transfer_call_objs_to_viz_objs(call_parser.parse())
         elif isinstance(self.value, ast.Lambda):
             return self
         else:
-            raise TypeError(f"{type(self.value)}는 정의되지 않았습니다.")
+            raise TypeError(f"[ExprGe]:{type(self.value)}는 정의되지 않았습니다.")
+
+    def transfer_call_objs_to_viz_objs(self, calls: list):
+        """
+        Call 객체를 시각화하는 Viz 객체로 변환
+        Args:
+            calls: call_parser를 통해 생성된 list[Call] 객체
+
+        Returns:
+            list[PrintViz]: 시각화된 Viz 객체
+        """
+        if isinstance(calls[0], Print):
+            return self.transfer_print_objs_to_viz_objs(calls)
+        else:
+            raise TypeError(f"[ExprGe]:{type(calls)}는 정의되지 않았습니다.")
+
+    def transfer_print_objs_to_viz_objs(self, print_objs: list[Print]):
+        """
+        Print 객체를 시각화하는 PrintViz 객체로 변환
+        Args:
+            print_objs:  call_parser를 통해 생성된 list[Print] 객체
+
+        Returns:
+            list[PrintViz]: 시각화된 PrintViz 객체
+        """
+        parsed_expressions = []
+        # print_objs에 있는 모든 expressions를 expressions에 추가
+        for print_obj in print_objs:
+            parsed_expressions.append(print_obj.expressions)
+
+        # 하이라이트 속성 추출
+        highlights = expressions_highlight_indices(parsed_expressions)
+
+        print_vizs = [
+            PrintViz(
+                id=self.elem_manager.get_call_id(self),
+                depth=self.elem_manager.get_depth(),
+                expr=expression,
+                highlight=highlight
+            )
+            for expression, highlight in zip(parsed_expressions, highlights)
+        ]
+        return print_vizs
 

--- a/app/analysis/generator/expr_generator.py
+++ b/app/analysis/generator/expr_generator.py
@@ -23,22 +23,22 @@ class ExprGenerator:
         # ast.Call 처리
         elif isinstance(self.value, ast.Call):
             call_parser = CallParser(self.value, self.elem_manager)
-            return self.convert_call_objs_to_vizs(call_parser.parse())
+            return self.convert_call_obj_to_vizs(call_parser.parse())
         elif isinstance(self.value, ast.Lambda):
             return self
         else:
             raise TypeError(f"[ExprGe]:{type(self.value)}는 정의되지 않았습니다.")
 
-    def convert_call_objs_to_vizs(self, call_obj):
+    def convert_call_obj_to_vizs(self, call_obj):
         """
         Call 객체를 List[Viz] 객체로 변환
         """
         if isinstance(call_obj, Print):
-            return self.convert_print_objs_to_print_vizs(call_obj)
+            return self.convert_print_obj_to_print_vizs(call_obj)
         else:
             raise TypeError(f"[ExprGe]:{type(call_obj)}는 정의되지 않았습니다.")
 
-    def convert_print_objs_to_print_vizs(self, print_obj: Print):
+    def convert_print_obj_to_print_vizs(self, print_obj: Print):
         """
         Print 객체를 List[PrintViz] 객체로 반환
         """

--- a/app/analysis/generator/expr_generator.py
+++ b/app/analysis/generator/expr_generator.py
@@ -23,29 +23,24 @@ class ExprGenerator:
         # ast.Call 처리
         elif isinstance(self.value, ast.Call):
             call_parser = CallParser(self.value, self.elem_manager)
-            return self.convert_call_objs_to_viz_objs(call_parser.parse())
+            return self.convert_call_objs_to_vizs(call_parser.parse())
         elif isinstance(self.value, ast.Lambda):
             return self
         else:
             raise TypeError(f"[ExprGe]:{type(self.value)}는 정의되지 않았습니다.")
 
-    def convert_call_objs_to_viz_objs(self, call_obj):
+    def convert_call_objs_to_vizs(self, call_obj):
         """
-        Call 객체를 시각화하는 Viz 객체로 변환
-        Args:
-            calls: call_parser를 통해 생성된 list[Call] 객체
-        Returns:
-            list[PrintViz]: 시각화된 Viz 객체
+        Call 객체를 List[Viz] 객체로 변환
         """
         if isinstance(call_obj, Print):
-            return self.convert_print_objs_to_viz_objs(call_obj)
+            return self.convert_print_objs_to_print_vizs(call_obj)
         else:
             raise TypeError(f"[ExprGe]:{type(call_obj)}는 정의되지 않았습니다.")
 
-    def convert_print_objs_to_viz_objs(self, print_obj: Print):
+    def convert_print_objs_to_print_vizs(self, print_obj: Print):
         """
-        Returns:
-            list[PrintViz]: 시각화된 PrintViz 객체
+        Print 객체를 List[PrintViz] 객체로 반환
         """
         # 하이라이트 속성 추출
         highlights = expressions_highlight_indices(print_obj.expressions)

--- a/app/analysis/generator/expr_generator.py
+++ b/app/analysis/generator/expr_generator.py
@@ -23,42 +23,32 @@ class ExprGenerator:
         # ast.Call 처리
         elif isinstance(self.value, ast.Call):
             call_parser = CallParser(self.value, self.elem_manager)
-            return self.transfer_call_objs_to_viz_objs(call_parser.parse())
+            return self.convert_call_objs_to_viz_objs(call_parser.parse())
         elif isinstance(self.value, ast.Lambda):
             return self
         else:
             raise TypeError(f"[ExprGe]:{type(self.value)}는 정의되지 않았습니다.")
 
-    def transfer_call_objs_to_viz_objs(self, calls: list):
+    def convert_call_objs_to_viz_objs(self, call_obj):
         """
         Call 객체를 시각화하는 Viz 객체로 변환
         Args:
             calls: call_parser를 통해 생성된 list[Call] 객체
-
         Returns:
             list[PrintViz]: 시각화된 Viz 객체
         """
-        if isinstance(calls[0], Print):
-            return self.transfer_print_objs_to_viz_objs(calls)
+        if isinstance(call_obj, Print):
+            return self.convert_print_objs_to_viz_objs(call_obj)
         else:
-            raise TypeError(f"[ExprGe]:{type(calls)}는 정의되지 않았습니다.")
+            raise TypeError(f"[ExprGe]:{type(call_obj)}는 정의되지 않았습니다.")
 
-    def transfer_print_objs_to_viz_objs(self, print_objs: list[Print]):
+    def convert_print_objs_to_viz_objs(self, print_obj: Print):
         """
-        Print 객체를 시각화하는 PrintViz 객체로 변환
-        Args:
-            print_objs:  call_parser를 통해 생성된 list[Print] 객체
-
         Returns:
             list[PrintViz]: 시각화된 PrintViz 객체
         """
-        parsed_expressions = []
-        # print_objs에 있는 모든 expressions를 expressions에 추가
-        for print_obj in print_objs:
-            parsed_expressions.append(print_obj.expressions)
-
         # 하이라이트 속성 추출
-        highlights = expressions_highlight_indices(parsed_expressions)
+        highlights = expressions_highlight_indices(print_obj.expressions)
 
         print_vizs = [
             PrintViz(
@@ -67,7 +57,7 @@ class ExprGenerator:
                 expr=expression,
                 highlight=highlight
             )
-            for expression, highlight in zip(parsed_expressions, highlights)
+            for expression, highlight in zip(print_obj.expressions, highlights)
         ]
         return print_vizs
 

--- a/app/analysis/generator/expr_generator.py
+++ b/app/analysis/generator/expr_generator.py
@@ -20,7 +20,7 @@ class ExprGenerator:
             return self
         elif isinstance(self.value, ast.BinOp):
             return self
-        # 함수
+        # ast.Call 처리
         elif isinstance(self.value, ast.Call):
             call_parser = CallParser(self.value, self.elem_manager)
             return self.transfer_call_objs_to_viz_objs(call_parser.parse())

--- a/app/analysis/generator/expr_generator.py
+++ b/app/analysis/generator/expr_generator.py
@@ -1,11 +1,15 @@
 # 시각화에 필요한 Expr를 만듦
 import ast
 
+from app.analysis.element_manager import CodeElementManager
+from app.analysis.generator.parser.call_parser import CallParser
+
 
 class ExprGenerator:
     # ast.Expr : 함수 호출과 같은 식이 반환 값으로 사용되지 않거나, 저장되지 않는 상태에서 그 자체문으로 나타나는 경우의 타입
-    def __init__(self, node: ast.Expr):
+    def __init__(self, node: ast.Expr, elem_manager: CodeElementManager):
         self.value = node.value
+        self.elem_manager = elem_manager
 
     def generate(self):
         if isinstance(self.value, ast.Name):
@@ -15,6 +19,7 @@ class ExprGenerator:
         elif isinstance(self.value, ast.BinOp):
             return self
         elif isinstance(self.value, ast.Call):
+            CallParser(self.value, self.elem_manager).parse()
             return self
         elif isinstance(self.value, ast.Lambda):
             return self

--- a/app/analysis/generator/expr_generator.py
+++ b/app/analysis/generator/expr_generator.py
@@ -1,0 +1,23 @@
+# 시각화에 필요한 Expr를 만듦
+import ast
+
+
+class ExprGenerator:
+    # ast.Expr : 함수 호출과 같은 식이 반환 값으로 사용되지 않거나, 저장되지 않는 상태에서 그 자체문으로 나타나는 경우의 타입
+    def __init__(self, node: ast.Expr):
+        self.value = node.value
+
+    def generate(self):
+        if isinstance(self.value, ast.Name):
+            return self
+        elif isinstance(self.value, ast.Constant):
+            return self
+        elif isinstance(self.value, ast.BinOp):
+            return self
+        elif isinstance(self.value, ast.Call):
+            return self
+        elif isinstance(self.value, ast.Lambda):
+            return self
+        else:
+            raise TypeError(f"{type(self.value)}는 정의되지 않았습니다.")
+

--- a/app/analysis/generator/parser/call_parser.py
+++ b/app/analysis/generator/parser/call_parser.py
@@ -41,11 +41,7 @@ class CallParser:
             if isinstance(arg, ast.BinOp):
                 binop_obj = BinopParser(arg, self.elem_manager).parse()
 
-                # 중간 연산 과정이 포함된 노드 생성
-                for parsed_expression in binop_obj.expressions:
-                    print_objs.append(Print(expressions=parsed_expression))
-
-        return print_objs
+        return Print(expressions=binop_obj.expressions)
 
 
 @dataclass

--- a/app/analysis/generator/parser/call_parser.py
+++ b/app/analysis/generator/parser/call_parser.py
@@ -1,0 +1,30 @@
+import ast
+
+from app.analysis.element_manager import CodeElementManager
+from app.analysis.generator.parser.name_parser import NameParser
+
+
+# ast.Call(func, args, keywords)
+# func : ast.Name이나 ast.Attribute
+# args : 전달의 인자의 리스트
+# keywords : 키워드별로 전달된 인수를 나타내는 키워드 개체 목록을 보유
+class CallParser:
+    def __init__(self, node: ast.Call, elem_manager: CodeElementManager):
+        self.elem_manager = elem_manager
+        self.func = node.func
+        self.args = node.args
+        self.keywords = node.keywords
+
+    def parse(self):
+        func_name = self.__parse_func()
+
+    def __get_func_name(self):
+        if isinstance(self.func, ast.Name):
+            name_obj = NameParser(node=self.func, elem_manager=self.elem_manager).parse()
+            return name_obj.id
+
+        elif isinstance(self.func, ast.Attribute):
+            raise TypeError(" ast.Attribute는 정의되지 않았습니다.")
+
+        else:
+            raise TypeError(f"{type(self.func)}정의되지 않았습니다.")

--- a/app/analysis/generator/parser/call_parser.py
+++ b/app/analysis/generator/parser/call_parser.py
@@ -1,10 +1,9 @@
 import ast
+from dataclasses import dataclass
 
 from app.analysis.element_manager import CodeElementManager
 from app.analysis.generator.parser.binop_parser import BinopParser
 from app.analysis.generator.parser.name_parser import NameParser
-from app.analysis.highlight import expressions_highlight_indices, create_highlighted_expression
-from app.analysis.models import Print
 
 
 # ast.Call(func, args, keywords)
@@ -22,7 +21,7 @@ class CallParser:
         func_name = self.__get_func_name()
 
         if func_name is 'print':
-            self.__print_parse()
+            return self.__print_parse()
 
     def __get_func_name(self):
         if isinstance(self.func, ast.Name):
@@ -36,19 +35,19 @@ class CallParser:
             raise TypeError(f"[call_parser] {type(self.func)}정의되지 않았습니다.")
 
     def __print_parse(self):
-        print_objects = []
+        print_objs = []
 
         for arg in self.args:
             if isinstance(arg, ast.BinOp):
-                binop = BinopParser(arg, self.elem_manager).parse()
-                # highlight 요소 생성
-                highlights = expressions_highlight_indices(binop.expressions)
-                # 중간 연산 과정이 포함된 노드 생성
-                for idx, parsed_expression in enumerate(binop.expressions):
-                    # 확인용 함수
-                    highlight_expr = create_highlighted_expression(parsed_expression, highlights[idx])
-                    print_obj = Print(id=self.elem_manager.get_call_id(self), depth=self.elem_manager.get_depth(),
-                                      expr=parsed_expression, highlight=highlights[idx])
-                    print_objects.append(print_obj)
+                binop_obj = BinopParser(arg, self.elem_manager).parse()
 
-        return print_objects
+                # 중간 연산 과정이 포함된 노드 생성
+                for parsed_expression in binop_obj.expressions:
+                    print_objs.append(Print(expressions=parsed_expression))
+
+        return print_objs
+
+
+@dataclass
+class Print:
+    expressions: list

--- a/app/analysis/generator/parser/call_parser.py
+++ b/app/analysis/generator/parser/call_parser.py
@@ -35,8 +35,6 @@ class CallParser:
             raise TypeError(f"[call_parser] {type(self.func)}정의되지 않았습니다.")
 
     def __print_parse(self):
-        print_objs = []
-
         for arg in self.args:
             if isinstance(arg, ast.BinOp):
                 binop_obj = BinopParser(arg, self.elem_manager).parse()

--- a/app/analysis/models.py
+++ b/app/analysis/models.py
@@ -63,7 +63,7 @@ class For:
 
 
 @dataclass(frozen=True)
-class Print:
+class PrintViz:
     id: int
     depth: int
     expr: str

--- a/tests/test_call_parser.py
+++ b/tests/test_call_parser.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+import ast
+import pytest
+
+from app.analysis.generator.parser.call_parser import CallParser
+from app.analysis.element_manager import CodeElementManager
+
+@pytest.fixture
+def elem_manager():
+    """Fixture to create a CodeElementManager instance."""
+    return MagicMock(spec=CodeElementManager)
+
+
+@pytest.fixture
+def call_parser(elem_manager):
+    # CallParser 인스턴스를 생성하는 함수를 반환
+    def _create_parser(node):
+        return CallParser(node, elem_manager)
+    return _create_parser
+
+
+@pytest.mark.parametrize(
+    "node, expect",
+    [
+        (ast.Call(func=ast.Name(id='print', ctx=ast.Load()), args=[], keywords=[]), 'print'),
+        (ast.Call(func=ast.Name(id='range', ctx=ast.Load()), args=[], keywords=[]), 'range'),
+    ]
+)
+def test_get_func_name(call_parser, node, expect):
+    """
+    ast.Call 노드가 주어졌을 때 함수 아이디를 제대로 가져오는지 테스트
+    :param node: ast.Call 노드
+    :param expect: 예상되는 함수 아이디
+    :return: None
+    """
+    parser = call_parser(node)
+    result = parser._CallParser__get_func_name()
+    assert result == expect

--- a/tests/test_call_parser.py
+++ b/tests/test_call_parser.py
@@ -27,7 +27,7 @@ def call_parser(elem_manager):
         (ast.Call(func=ast.Name(id='range', ctx=ast.Load()), args=[], keywords=[]), 'range'),
     ]
 )
-def test_get_func_name(call_parser, node, expect):
+def test_get_func_name_success(call_parser, node, expect):
     """
     ast.Call 노드가 주어졌을 때 함수 아이디를 제대로 가져오는지 테스트
     :param node: ast.Call 노드
@@ -37,3 +37,22 @@ def test_get_func_name(call_parser, node, expect):
     parser = call_parser(node)
     result = parser._CallParser__get_func_name()
     assert result == expect
+
+
+@pytest.mark.parametrize(
+    "node, expect",
+    [
+        (ast.Call(func=ast.Name(id='print', ctx=ast.Load()), args=[], keywords=[]), ''),
+        (ast.Call(func=ast.Name(id='range', ctx=ast.Load()), args=[], keywords=[]), 'print'),
+    ]
+)
+def test_get_func_name_failure(call_parser, node, expect):
+    """
+    ast.Call 노드가 주어졌을 때 함수 아이디를 제대로 가져오는지 테스트
+    :param node: ast.Call 노드
+    :param expect: 예상되는 함수 아이디
+    :return: None
+    """
+    parser = call_parser(node)
+    result = parser._CallParser__get_func_name()
+    assert result != expect

--- a/tests/test_call_parser.py
+++ b/tests/test_call_parser.py
@@ -62,10 +62,6 @@ test_data = [
 def test_get_func_name(call_parser, node, expect, success):
     """
     ast.Call 노드가 주어졌을 때 함수 아이디를 제대로 가져오는지 테스트
-        :param node: ast.Call 노드
-        :param expect: 예상되는 함수 아이디
-        :param success: 테스트가 성공해야 하는지 (True), 실패해야 하는지 (False)
-        :return: None
     """
     parser = call_parser(node)
     result = parser._CallParser__get_func_name()
@@ -82,9 +78,6 @@ def test_get_func_name(call_parser, node, expect, success):
 def test_print_parse(create_ast_node, call_parser, code, expect):
     """
     ast.Call 노드의 함수가 print일 때, print_parse() 함수가 제대로 동작하는지 테스트
-        :param create_ast_node: 코드를 받아 ast 노드로 변환하는 함수
-        :param call_parser: CallParser 인스턴스를 생성하는 함수
-        :return: None
     """
     parser = call_parser(create_ast_node(code))
     result = parser._CallParser__print_parse()

--- a/tests/test_call_parser.py
+++ b/tests/test_call_parser.py
@@ -1,10 +1,11 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import ast
 import pytest
 
-from app.analysis.generator.parser.call_parser import CallParser
+from app.analysis.generator.parser.call_parser import CallParser, Print
 from app.analysis.element_manager import CodeElementManager
+
 
 @pytest.fixture
 def elem_manager():
@@ -19,7 +20,33 @@ def call_parser(elem_manager):
     # CallParser 인스턴스를 생성하는 함수를 반환
     def _create_parser(node):
         return CallParser(node, elem_manager)
+
     return _create_parser
+
+
+@pytest.fixture
+def create_ast_node():
+    # 코드를 ast 노드로 변환하는 함수를 반환
+    def _create_ast_node(code):
+        # ast.Call 반환
+        return ast.parse(code).body[0].value
+
+    return _create_ast_node
+
+
+@pytest.mark.parametrize("code, expect", [
+    ("print(1 + 2)", [Print(expressions="1 + 2"), Print(expressions=3)]),
+])
+def test_parse(create_ast_node, call_parser, code, expect):
+    """
+    ast.Call 타입으로 print 노드일 때 List[Print]를 생성하는지 테스트
+    """
+    with patch.object(CallParser, '_CallParser__print_parse',
+                      return_value=[Print(expressions="1 + 2"), Print(expressions=3)]), \
+            patch.object(CallParser, "_CallParser__get_func_name", return_value='print'):
+        parser = call_parser(create_ast_node(code))
+        result = parser.parse()
+        assert result == expect
 
 
 # 테스트 데이터를 별도의 변수에 저장
@@ -35,10 +62,10 @@ test_data = [
 def test_get_func_name(call_parser, node, expect, success):
     """
     ast.Call 노드가 주어졌을 때 함수 아이디를 제대로 가져오는지 테스트
-    :param node: ast.Call 노드
-    :param expect: 예상되는 함수 아이디
-    :param success: 테스트가 성공해야 하는지 (True), 실패해야 하는지 (False)
-    :return: None
+        :param node: ast.Call 노드
+        :param expect: 예상되는 함수 아이디
+        :param success: 테스트가 성공해야 하는지 (True), 실패해야 하는지 (False)
+        :return: None
     """
     parser = call_parser(node)
     result = parser._CallParser__get_func_name()

--- a/tests/test_call_parser.py
+++ b/tests/test_call_parser.py
@@ -20,39 +20,27 @@ def call_parser(elem_manager):
     return _create_parser
 
 
-@pytest.mark.parametrize(
-    "node, expect",
-    [
-        (ast.Call(func=ast.Name(id='print', ctx=ast.Load()), args=[], keywords=[]), 'print'),
-        (ast.Call(func=ast.Name(id='range', ctx=ast.Load()), args=[], keywords=[]), 'range'),
-    ]
-)
-def test_get_func_name_success(call_parser, node, expect):
+# 테스트 데이터를 별도의 변수에 저장
+test_data = [
+    (ast.Call(func=ast.Name(id='print', ctx=ast.Load()), args=[], keywords=[]), 'print', True),
+    (ast.Call(func=ast.Name(id='range', ctx=ast.Load()), args=[], keywords=[]), 'range', True),
+    (ast.Call(func=ast.Name(id='print', ctx=ast.Load()), args=[], keywords=[]), '', False),
+    (ast.Call(func=ast.Name(id='range', ctx=ast.Load()), args=[], keywords=[]), 'print', False),
+]
+
+
+@pytest.mark.parametrize("node, expect, success", test_data)
+def test_get_func_name(call_parser, node, expect, success):
     """
     ast.Call 노드가 주어졌을 때 함수 아이디를 제대로 가져오는지 테스트
     :param node: ast.Call 노드
     :param expect: 예상되는 함수 아이디
+    :param success: 테스트가 성공해야 하는지 (True), 실패해야 하는지 (False)
     :return: None
     """
     parser = call_parser(node)
     result = parser._CallParser__get_func_name()
-    assert result == expect
-
-
-@pytest.mark.parametrize(
-    "node, expect",
-    [
-        (ast.Call(func=ast.Name(id='print', ctx=ast.Load()), args=[], keywords=[]), ''),
-        (ast.Call(func=ast.Name(id='range', ctx=ast.Load()), args=[], keywords=[]), 'print'),
-    ]
-)
-def test_get_func_name_failure(call_parser, node, expect):
-    """
-    ast.Call 노드가 주어졌을 때 함수 아이디를 제대로 가져오는지 테스트
-    :param node: ast.Call 노드
-    :param expect: 예상되는 함수 아이디
-    :return: None
-    """
-    parser = call_parser(node)
-    result = parser._CallParser__get_func_name()
-    assert result != expect
+    if success:
+        assert result == expect
+    else:
+        assert result != expect

--- a/tests/test_call_parser.py
+++ b/tests/test_call_parser.py
@@ -9,7 +9,9 @@ from app.analysis.element_manager import CodeElementManager
 @pytest.fixture
 def elem_manager():
     """Fixture to create a CodeElementManager instance."""
-    return MagicMock(spec=CodeElementManager)
+    mock = MagicMock(spec=CodeElementManager)
+    mock.get_variable_value.return_value = 1
+    return mock
 
 
 @pytest.fixture
@@ -44,3 +46,19 @@ def test_get_func_name(call_parser, node, expect, success):
         assert result == expect
     else:
         assert result != expect
+
+
+@pytest.mark.parametrize("code, expect", [
+    ("print(1 + 2)", [Print(expressions="1 + 2"), Print(expressions=3)]),
+    ("print(a + 2)", [Print(expressions="a + 2"), Print(expressions="1 + 2"), Print(expressions=3)])
+])
+def test_print_parse(create_ast_node, call_parser, code, expect):
+    """
+    ast.Call 노드의 함수가 print일 때, print_parse() 함수가 제대로 동작하는지 테스트
+        :param create_ast_node: 코드를 받아 ast 노드로 변환하는 함수
+        :param call_parser: CallParser 인스턴스를 생성하는 함수
+        :return: None
+    """
+    parser = call_parser(create_ast_node(code))
+    result = parser._CallParser__print_parse()
+    assert result == expect

--- a/tests/test_call_parser.py
+++ b/tests/test_call_parser.py
@@ -35,14 +35,14 @@ def create_ast_node():
 
 
 @pytest.mark.parametrize("code, expect", [
-    ("print(1 + 2)", [Print(expressions="1 + 2"), Print(expressions=3)]),
+    ("print(1 + 2)", Print(expressions=["1 + 2", '3']))
 ])
 def test_parse(create_ast_node, call_parser, code, expect):
     """
     ast.Call 타입으로 print 노드일 때 List[Print]를 생성하는지 테스트
     """
     with patch.object(CallParser, '_CallParser__print_parse',
-                      return_value=[Print(expressions="1 + 2"), Print(expressions=3)]), \
+                      return_value=Print(expressions=["1 + 2", '3'])), \
             patch.object(CallParser, "_CallParser__get_func_name", return_value='print'):
         parser = call_parser(create_ast_node(code))
         result = parser.parse()
@@ -76,8 +76,8 @@ def test_get_func_name(call_parser, node, expect, success):
 
 
 @pytest.mark.parametrize("code, expect", [
-    ("print(1 + 2)", [Print(expressions="1 + 2"), Print(expressions=3)]),
-    ("print(a + 2)", [Print(expressions="a + 2"), Print(expressions="1 + 2"), Print(expressions=3)])
+    ("print(1 + 2)", Print(expressions=["1 + 2", 3])),
+    ("print(a + 2)", Print(expressions=["a + 2", "1 + 2", 3]))
 ])
 def test_print_parse(create_ast_node, call_parser, code, expect):
     """


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #58 
- close #61 

## 📝 작업 내용

- call_parser.py의 __get_func_name 테스트
- call_parser.py 파일 생성 후 Ast.Call 타입을 파싱할 수 있는 뼈대 생성
- expr_generator.py파일 생성 후 Ast.Expr 타입을 파싱할 수 있는 뼈대 생성
- expr_generator.py에서 print 노드가 들어왔을 때 paring 후 시각화 노드 리턴

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- c7c278e0edd84dbdb455086581fa367ac41e078d 중점으로 봐주세요
- 5062c2a99111ceb51bc5690d96b29bb6f8c8ae11 pytest를 이용해서 테스트 코드를 작성했습니다. 
