### PR TITLE
[#45]fix: '//' 연산 지원 안됨

### DIFF
--- a/app/analysis/generator/for_generator.py
+++ b/app/analysis/generator/for_generator.py
@@ -6,7 +6,7 @@ from app.analysis.generator.highlight.for_highlight import get_highlight_attr
 from app.analysis.generator.parser.binop_parser import BinopParser
 from app.analysis.generator.parser.constant_parser import ConstantParser
 from app.analysis.generator.parser.name_parser import NameParser
-from app.analysis.models import Condition, ForViz
+from app.analysis.models import ConditionViz, ForViz
 
 
 class ForGenerator:
@@ -62,7 +62,7 @@ class ForGenerator:
         elif len(identifier_list) == 3:
             start, end, step = identifier_list
 
-        return Condition(target=target_name, start=start, end=end, step=step, cur=start)
+        return ConditionViz(target=target_name, start=start, end=end, step=step, cur=start)
 
     def __create_body_vizs(self):
         "for문의 body를 파싱해서 viz 객체를 생성하는 함수"

--- a/app/analysis/generator/for_generator.py
+++ b/app/analysis/generator/for_generator.py
@@ -56,11 +56,11 @@ class ForGenerator:
         identifier_list = self.__get_identifiers()
 
         if len(identifier_list) == 1:
-            end = identifier_list[0]
+            end = int(identifier_list[0])
         elif len(identifier_list) == 2:
-            start, end = identifier_list
+            start, end = map(int, identifier_list)
         elif len(identifier_list) == 3:
-            start, end, step = identifier_list
+            start, end, step = map(int, identifier_list)
 
         return ConditionViz(target=target_name, start=start, end=end, step=step, cur=start)
 

--- a/app/analysis/generator/highlight/for_highlight.py
+++ b/app/analysis/generator/highlight/for_highlight.py
@@ -1,5 +1,5 @@
-from app.analysis.models import Condition
+from app.analysis.models import ConditionViz
 
 
-def get_highlight_attr(condition: Condition):
+def get_highlight_attr(condition: ConditionViz):
     return condition.changed_attr()

--- a/app/analysis/generator/parser/binop_parser.py
+++ b/app/analysis/generator/parser/binop_parser.py
@@ -61,7 +61,10 @@ class BinopParser:
             return left * right
 
         elif isinstance(self.__op, ast.Div):
-            return left / right
+            return left // right    # 정수로 계산
+
+        elif isinstance(self.__op, ast.FloorDiv):
+            return left / right     # 실수로 계산
 
         else:
             raise NotImplementedError(f"Unsupported operator: {type(self.__op)}")

--- a/app/analysis/generator/parser/binop_parser.py
+++ b/app/analysis/generator/parser/binop_parser.py
@@ -60,11 +60,11 @@ class BinopParser:
         elif isinstance(self.__op, ast.Mult):
             return left * right
 
-        elif isinstance(self.__op, ast.Div):
-            return left // right    # 정수로 계산
+        elif isinstance(self.__op, ast.Div):  # '/'
+            return left / right  # 실수로 계산
 
-        elif isinstance(self.__op, ast.FloorDiv):
-            return left / right     # 실수로 계산
+        elif isinstance(self.__op, ast.FloorDiv):  # '//'
+            return left // right  # 정수로 계산
 
         else:
             raise NotImplementedError(f"Unsupported operator: {type(self.__op)}")

--- a/app/analysis/highlight.py
+++ b/app/analysis/highlight.py
@@ -1,7 +1,7 @@
-from app.analysis.models import Condition
+from app.analysis.models import ConditionViz
 
 
-def for_highlight(condition: Condition):
+def for_highlight(condition: ConditionViz):
     return condition.changed_attr()
 
 

--- a/app/analysis/models.py
+++ b/app/analysis/models.py
@@ -28,7 +28,7 @@ class Variable:
 
 
 @dataclass
-class Condition:
+class ConditionViz:
     target: str
     cur: int
     start: int
@@ -36,7 +36,7 @@ class Condition:
     step: int
 
     def copy_with_new_cur(self, new_cur):
-        return Condition(self.target, new_cur, self.start, self.end, self.step)
+        return ConditionViz(self.target, new_cur, self.start, self.end, self.step)
 
     def changed_attr(self):
         if self.start == self.cur:
@@ -49,7 +49,7 @@ class Condition:
 class ForViz:
     id: int
     depth: int
-    condition: Condition
+    condition: ConditionViz
     highlight: []
     type: str = "for"
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #45 

## 📝 작업 내용

- '//' 연산에 대한 binop 연산처리가 없어서 추가했습니다.

        elif isinstance(self.__op, ast.Div):  # '/'
            return left / right  # 실수로 계산

        elif isinstance(self.__op, ast.FloorDiv):  # '//'
            return left // right  # 정수로 계산
- For문의 조건절 객체인 condition을 생성할 때 cur, end, step 인자가 실수가 들어오는 경우 int 인자로 형변환했습니다.
 -> range의 인자로 무조건 int형만 들어올 수 있다고 합니다.

## 리뷰 중점
- issue 페이지에 조사한 내용도 적었습니다.
