### PR TITLE
[#33] feat: print문 console창 출력 및 BodyGenerator 분리

### DIFF
--- a/app/analysis/code_analyzer.py
+++ b/app/analysis/code_analyzer.py
@@ -1,32 +1,13 @@
 import ast
 
 from app.analysis.element_manager import CodeElementManager
-from app.analysis.generator.assign_generator import AssignGenerator
-from app.analysis.generator.expr_generator import ExprGenerator
-from app.analysis.generator.for_generator import ForGenerator
-from app.analysis.step_manager import StepManager
+from app.analysis.generator.body_generator import BodyGenerator
 
 
 class CodeAnalyzer:
 
-    def __init__(self, elem_manager: CodeElementManager, step_manager: StepManager):
+    def __init__(self, elem_manager: CodeElementManager):
         self.elem_manager = elem_manager
-        self.step_manager = step_manager
 
-    def visualize_code(self, parsed_ast):
-        for node in parsed_ast.body:
-            self.parse_node(node)
-        return self.step_manager.get_steps()
-
-    def parse_node(self, node):
-        if isinstance(node, ast.Assign):
-            assign_vizs = AssignGenerator.generate(node, self.elem_manager)
-            self.step_manager.add_steps(assign_vizs)
-
-        elif isinstance(node, ast.For):
-            steps = ForGenerator.generate(node, self.elem_manager)
-            self.step_manager.add_steps(steps)
-
-        elif isinstance(node, ast.Expr):
-            steps = ExprGenerator.generate(node, self.elem_manager)
-            self.step_manager.add_steps(steps)
+    def visualize_code(self, parsed_ast: ast.Module):
+        return BodyGenerator.generate(parsed_ast.body, self.elem_manager)

--- a/app/analysis/element_manager.py
+++ b/app/analysis/element_manager.py
@@ -4,7 +4,7 @@ class CodeElementManager:
         self.call_id = 0
         self.call_ids = {}
         self.variables_value = {}
-        self.depth = 1
+        self.depth = 0
 
     def get_call_id(self, node):
         if node in self.call_ids:

--- a/app/analysis/generator/body_generator.py
+++ b/app/analysis/generator/body_generator.py
@@ -1,0 +1,42 @@
+import ast
+
+from app.analysis.element_manager import CodeElementManager
+from app.analysis.generator.assign_generator import AssignGenerator
+from app.analysis.generator.expr_generator import ExprGenerator
+from app.analysis.generator.for_generator import ForGenerator
+
+
+class BodyGenerator:
+
+    def __init__(self, body_list, elem_manager: CodeElementManager):
+        self.__body = body_list
+        self.__elem_manager = elem_manager
+
+    @staticmethod
+    def generate(body: ast, elem_manager: CodeElementManager):
+        body_generator = BodyGenerator(body, elem_manager)
+        return body_generator.__parse_body()
+
+    def __parse_body(self):
+        self.__elem_manager.increase_depth()
+        steps = []
+
+        for node in self.__body:
+            if isinstance(node, ast.Assign):
+                assign_vizs = AssignGenerator.generate(node, self.__elem_manager)
+                steps += assign_vizs
+
+            elif isinstance(node, ast.For):
+                for_vizs = ForGenerator.generate(node, self.__elem_manager)
+                steps += for_vizs
+
+            elif isinstance(node, ast.Expr):
+                expr_vizs = ExprGenerator.generate(node, self.__elem_manager)
+                steps += expr_vizs
+
+            else:
+                raise TypeError(f"지원하지 않는 노드 타입입니다.: {type(node)}")
+
+        self.__elem_manager.decrease_depth()
+
+        return steps

--- a/app/analysis/generator/expr_generator.py
+++ b/app/analysis/generator/expr_generator.py
@@ -1,4 +1,3 @@
-# 시각화에 필요한 Expr를 만듦
 import ast
 
 from app.analysis.element_manager import CodeElementManager
@@ -10,38 +9,39 @@ from app.analysis.models import PrintViz
 class ExprGenerator:
     # ast.Expr : 함수 호출과 같은 식이 반환 값으로 사용되지 않거나, 저장되지 않는 상태에서 그 자체문으로 나타나는 경우의 타입
     def __init__(self, node: ast.Expr, elem_manager: CodeElementManager):
-        self.value = node.value
-        self.elem_manager = elem_manager
+        self.__value = node.value
+        self.__elem_manager = elem_manager
 
     @staticmethod
     def generate(node: ast.Expr, elem_manager: CodeElementManager):
         expr_generator = ExprGenerator(node, elem_manager)
+        return expr_generator.__get_parse_value()
 
-        if isinstance(node.value, ast.Name):
-            return node
-        elif isinstance(node.value, ast.Constant):
-            return node
-        elif isinstance(node.value, ast.BinOp):
+    def __get_parse_value(self):
+        if isinstance(self.__value, ast.Name):
             return
-        # ast.Call 처리
-        elif isinstance(node.value, ast.Call):
-            call_obj = CallParser(node.value, elem_manager).parse()
-            return expr_generator.convert_call_obj_to_vizs(call_obj)
-        elif isinstance(node.value, ast.Lambda):
-            return node
+        elif isinstance(self.__value, ast.Constant):
+            return
+        elif isinstance(self.__value, ast.BinOp):
+            return
+        elif isinstance(self.__value, ast.Call):
+            call_obj = CallParser.parse(self.__value, self.__elem_manager)
+            return self.__convert_call_obj_to_vizs(call_obj)
+        elif isinstance(self.__value, ast.Lambda):
+            return
         else:
-            raise TypeError(f"[ExprGe]:{type(node.value)}는 정의되지 않았습니다.")
+            raise TypeError(f"[ExprGe]:{type(self.__value)}는 정의되지 않았습니다.")
 
-    def convert_call_obj_to_vizs(self, call_obj):
+    def __convert_call_obj_to_vizs(self, call_obj):
         """
         Call 객체를 List[Viz] 객체로 변환
         """
         if isinstance(call_obj, Print):
-            return self.convert_print_obj_to_print_vizs(call_obj)
+            return self.__convert_print_obj_to_print_vizs(call_obj)
         else:
             raise TypeError(f"[ExprGe]:{type(call_obj)}는 정의되지 않았습니다.")
 
-    def convert_print_obj_to_print_vizs(self, print_obj: Print):
+    def __convert_print_obj_to_print_vizs(self, print_obj: Print):
         """
         Print 객체를 List[PrintViz] 객체로 반환
         """
@@ -50,12 +50,12 @@ class ExprGenerator:
 
         print_vizs = [
             PrintViz(
-                id=self.elem_manager.get_call_id(self),
-                depth=self.elem_manager.get_depth(),
-                expr=expression,
-                highlight=highlight
+                id=self.__elem_manager.get_call_id(self),
+                depth=self.__elem_manager.get_depth(),
+                expr=print_obj.expressions[idx],
+                highlight=highlights[idx],
+                console=print_obj.console if idx == len(print_obj.expressions) - 1 else None
             )
-            for expression, highlight in zip(print_obj.expressions, highlights)
+            for idx in range(len(print_obj.expressions))
         ]
         return print_vizs
-

--- a/app/analysis/generator/for_generator.py
+++ b/app/analysis/generator/for_generator.py
@@ -3,10 +3,8 @@ import ast
 from app.analysis.element_manager import CodeElementManager
 from app.analysis.generator.expr_generator import ExprGenerator
 from app.analysis.generator.highlight.for_highlight import get_highlight_attr
-from app.analysis.generator.parser.binop_parser import BinopParser
-from app.analysis.generator.parser.constant_parser import ConstantParser
-from app.analysis.generator.parser.name_parser import NameParser
 from app.analysis.models import ConditionViz, ForViz
+from app.analysis.generator.parser.call_parser import CallParser
 
 
 class ForGenerator:
@@ -17,14 +15,14 @@ class ForGenerator:
         self.__elem_manager = elem_manager
 
     @staticmethod
-    def generate(node: ast.Assign, elem_manager: CodeElementManager):
+    def generate(node: ast.For, elem_manager: CodeElementManager):
         for_generator = ForGenerator(node, elem_manager)
 
         return for_generator.__create_for_viz(node, elem_manager)
 
     def __create_for_viz(self, node: ast.For, elem_manager):
         # Condition 객체 생성
-        id = elem_manager.get_call_id(node)
+        call_id = elem_manager.get_call_id(node)
         target_name = node.target.id
         condition = self.__create_condition_viz(target_name)
 
@@ -33,9 +31,10 @@ class ForGenerator:
         for i in range(condition.start, condition.end, condition.step):
             # target 업데이트
             elem_manager.add_variable_value(name=target_name, value=i)
+
             # for step 추가
             vizs.append(
-                ForViz(id=id,
+                ForViz(id=call_id,
                        depth=elem_manager.get_depth(),
                        condition=condition,
                        highlight=get_highlight_attr(condition))
@@ -87,17 +86,11 @@ class ForGenerator:
         return vizs
 
     def __get_identifiers(self):
-        identifier_list = []
-        for arg_node in self.__iter.args:
-            if isinstance(arg_node, ast.Name):  # 변수인 경우
-                identifier = NameParser.parse(arg_node, self.__elem_manager)
-            elif isinstance(arg_node, ast.Constant):  # 상수인 경우
-                identifier = ConstantParser.parse(arg_node)
-            elif isinstance(arg_node, ast.BinOp):  # 연산인 경우
-                identifier = BinopParser.parse(arg_node, self.__elem_manager)
-            else:
-                raise TypeError(f"[ForGenerator]: Unsupported node type: {type(arg_node)}")
 
-            identifier_list.append(identifier.value)
-
-        return identifier_list
+        if isinstance(self.__iter, ast.Call):
+            range_obj = CallParser.parse(self.__iter, self.__elem_manager)
+            return range_obj.identifier_list
+        elif isinstance(self.__iter, ast.List):
+            return
+        else:
+            raise TypeError(f"[ForGenerator]: Unsupported node type: {type(self.__iter)}")

--- a/app/analysis/generator/parser/call_parser.py
+++ b/app/analysis/generator/parser/call_parser.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass
 
 from app.analysis.element_manager import CodeElementManager
 from app.analysis.generator.parser.binop_parser import BinopParser
+from app.analysis.generator.parser.constant_parser import ConstantParser
 from app.analysis.generator.parser.name_parser import NameParser
+from app.analysis.util import util
 
 
 # ast.Call(func, args, keywords)
@@ -12,36 +14,104 @@ from app.analysis.generator.parser.name_parser import NameParser
 # keywords : 키워드별로 전달된 인수를 나타내는 키워드 개체 목록을 보유
 class CallParser:
     def __init__(self, node: ast.Call, elem_manager: CodeElementManager):
-        self.elem_manager = elem_manager
-        self.func = node.func
-        self.args = node.args
-        self.keywords = node.keywords
+        self.__elem_manager = elem_manager
+        self.__func = node.func
+        self.__args = node.args
+        self.__keywords = node.keywords
 
-    def parse(self):
-        func_name = self.__get_func_name()
+    @staticmethod
+    def parse(node: ast.Call, elem_manager: CodeElementManager):
+        call_parser = CallParser(node, elem_manager)
+        func_name = call_parser.__get_func_name()
 
-        if func_name is 'print':
-            return self.__print_parse()
+        if func_name == "print":
+            return call_parser.__print_parse()
+
+        elif func_name == "range":
+            return call_parser.__range_parse()
+
+        else:
+            raise TypeError(f"[CallParser]: {func_name}는 정의되지 않았습니다.")
 
     def __get_func_name(self):
-        if isinstance(self.func, ast.Name):
-            name_obj = NameParser.parse(node=self.func, elem_manager=self.elem_manager)
-            return name_obj.id
+        if isinstance(self.__func, ast.Name):
+            return self.__func.id
 
-        elif isinstance(self.func, ast.Attribute):
+        elif isinstance(self.__func, ast.Attribute):
             raise TypeError("[call_parser] ast.Attribute는 정의되지 않았습니다.")
 
         else:
-            raise TypeError(f"[call_parser] {type(self.func)}정의되지 않았습니다.")
+            raise TypeError(f"[call_parser] {type(self.__func)}정의되지 않았습니다.")
 
     def __print_parse(self):
-        for arg in self.args:
-            if isinstance(arg, ast.BinOp):
-                binop_obj = BinopParser.parse(arg, self.elem_manager)
+        keyword_dict = self.__print_keyword_parse()
+        expressions = []
 
-        return Print(expressions=binop_obj.expressions)
+        for arg in self.__args:
+            if isinstance(arg, ast.BinOp):
+                binop_obj = BinopParser.parse(arg, self.__elem_manager)
+                expressions.append(binop_obj.expressions)
+
+            elif isinstance(arg, ast.Name):
+                name_obj = NameParser.parse(arg, self.__elem_manager)
+                expressions.append(name_obj.expressions)
+
+            elif isinstance(arg, ast.Constant):
+                constant_obj = ConstantParser.parse(arg)
+                expressions.append(constant_obj.expressions)
+
+            else:
+                raise TypeError(f"[call_parser] {type(arg)}는 정의되지 않았습니다.")
+
+        transposed_expressions = util.transpose_with_last_fill(expressions)
+
+        print_values = []
+        for expressions in transposed_expressions:
+            str_expression = keyword_dict["sep"].join(expressions)
+            print_values.append(str_expression)
+
+        return Print(expressions=print_values, console=print_values[-1] + keyword_dict["end"])
+
+    # print 함수의 키워드 파싱 : end, sep만 지원 Todo. file, flush
+    def __print_keyword_parse(self):
+        keyword_dict = {"sep": " ", "end": "\n"}
+        for keyword in self.__keywords:
+            if keyword.arg == 'sep':
+                constant = ConstantParser.parse(keyword.value)
+                keyword_dict["sep"] = constant.value
+
+            if keyword.arg == 'end':
+                constant = ConstantParser.parse(keyword.value)
+                keyword_dict["end"] = constant.value
+
+        return keyword_dict
+
+    def __range_parse(self):
+        identifier_list = []
+        for arg_node in self.__args:
+            if isinstance(arg_node, ast.Name):  # 변수인 경우
+                identifier = NameParser.parse(arg_node, self.__elem_manager)
+
+            elif isinstance(arg_node, ast.Constant):  # 상수인 경우
+                identifier = ConstantParser.parse(arg_node)
+
+            elif isinstance(arg_node, ast.BinOp):  # 연산인 경우
+                identifier = BinopParser.parse(arg_node, self.__elem_manager)
+
+            else:
+                raise TypeError(f"[ForGenerator]: Unsupported node type: {type(arg_node)}")
+
+            identifier_list.append(identifier.value)
+
+        return Range(identifier_list=identifier_list)
 
 
 @dataclass
 class Print:
     expressions: list
+    console: str
+
+
+@dataclass
+class Range:
+    identifier_list: list

--- a/app/analysis/models.py
+++ b/app/analysis/models.py
@@ -68,6 +68,7 @@ class PrintViz:
     depth: int
     expr: str
     highlight: []
+    console: str
     type: str = "print"
 
 

--- a/app/analysis/util/util.py
+++ b/app/analysis/util/util.py
@@ -5,3 +5,19 @@ def replace_word(expression, original_word, new_word):
     pattern = rf'\b{original_word}\b'
     replaced_expression = re.sub(pattern, str(new_word), expression)
     return replaced_expression
+
+
+# 변수들의 표현식 리스트를 받아와서 배열의 행과 열을 바꿔주고 마지막 값으로 채워주는 함수
+# [["10"], ["a+13", "5+13", "28"], ["b", "4"]] -> [["10", "a+13", "b"], ["10", "5+13", "4"], ["10", "28", "4"]]
+def transpose_with_last_fill(expressions):
+    max_length = max(len(sublist) for sublist in expressions)
+
+    tuple_value = []
+    for i in range(max_length):
+        current_tuple = list(
+            sublist[i] if isinstance(sublist, list) and i < len(sublist) else sublist[-1]
+            for sublist in expressions
+        )
+        tuple_value.append(current_tuple)
+
+    return tuple_value


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #33 

## 📝 작업 내용

- print문 console창 출력 : PrintViz 생성시 마지막 print에 console:"출력데이터" 형식이 추가됨
- print문의 기능 추가 : ','를 기준으로 여러 인자를 받아 한줄로 출력하는 기능 추가, keyword(sep, end) 추가
- BodyGenerator 생성 : CodeAnalyzer에서 수행하던 body로직을 BodyGenerator class로 분리함
- ForGenerator에서 수행하던 Call(range) 로직 분리

### 스크린샷 (선택)
- print문 console창 출력
<img width="288" alt="스크린샷 2024-06-17 오후 5 32 10" src="https://github.com/Co-due/Code-Analysis-Server/assets/105411445/ae75cccd-3e1a-4153-a83a-5071d2f065f8">


## 💬 리뷰 요구사항(선택)

- BodyGenerator로 분리하면서 step의 관리가 필요 없어졌다고 생각해 StepManager() 삭제
- ExprGenerator에 private 처리가 아예 안되어있어서 제가 했습니다. 다음부터는 컨벤션에 맞게 작성 요망
- range로직을 CallParser가 수행하도록 수정했습니다.

이상으로 이상한 부분에 대해 코멘트 남겨주시면 수정하겠습니다!