### PR TITLE
[#97] refactor: for문 파싱 로직 decoupling

### DIFF
--- a/app/analysis/generator/assign_generator.py
+++ b/app/analysis/generator/assign_generator.py
@@ -25,7 +25,7 @@ class AssignGenerator:
         # 결과 계산 후 저장
         calculated_node = assign_generator.__calculate_node()
         for target_name in parsed_target_names:
-            elem_manager.add_variable_value(name=target_name, value=calculated_node["value"])
+            elem_manager.set_element(name=target_name, value=calculated_node["value"])
 
         # 표현식 변환 후 steps 생성
         assign_vizs = assign_generator.__create_assign_viz_steps(parsed_target_names, calculated_node["expressions"])

--- a/app/analysis/generator/for_generator.py
+++ b/app/analysis/generator/for_generator.py
@@ -29,14 +29,16 @@ class ForGenerator:
         vizs = []
         for i in range(condition.start, condition.end, condition.step):
             # target 업데이트
-            self.__elem_manager.add_variable_value(name=target_name, value=i)
+            self.__elem_manager.set_element(name=target_name, value=i)
 
             # for step 추가
             vizs.append(
-                ForViz(id=self.__call_id,
-                       depth=self.__elem_manager.get_depth(),
-                       condition=condition,
-                       highlight=get_highlight_attr(condition))
+                ForViz(
+                    id=self.__call_id,
+                    depth=self.__elem_manager.get_depth(),
+                    condition=condition,
+                    highlight=get_highlight_attr(condition),
+                )
             )
 
             # 순환 참조 문제로 locally import

--- a/app/route.py
+++ b/app/route.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from app.visualize.analysis.element_manager import CodeElementManager
-from app.visualize.code_analyzer import CodeAnalyzer
+from app.visualize.code_analyzer import CodeVisualizer
 
 app = FastAPI()
 
@@ -34,9 +34,6 @@ def read_root():
 @app.post("/v1/python")
 def read_root(request_code: RequestCode):
     # 코드 분석 인스턴스 생성
-    code_analyzer = CodeAnalyzer(CodeElementManager())
+    code_analyzer = CodeVisualizer(request_code)
 
-    # 소스 코드를 추상 구문 트리로 변환
-    parsed_ast = ast.parse(request_code.source_code)
-
-    return code_analyzer.visualize_code(parsed_ast)
+    return code_analyzer.visualize_code()

--- a/app/visualize/analysis/element_manager.py
+++ b/app/visualize/analysis/element_manager.py
@@ -18,7 +18,7 @@ class CodeElementManager:
         self.call_id += 1
         return self.call_id
 
-    def get_variable_value(self, name):
+    def get_element(self, name):
         if name in self.variables_value:
             return self.variables_value[name]
 

--- a/app/visualize/analysis/element_manager.py
+++ b/app/visualize/analysis/element_manager.py
@@ -24,7 +24,7 @@ class CodeElementManager:
 
         raise NameError(f"변수 '{name}'가 정의되지 않았습니다. ")
 
-    def add_variable_value(self, name, value):
+    def set_element(self, name, value):
         if isinstance(name, tuple) and isinstance(value, tuple):
             for i in range(len(name)):
                 self.variables_value[name[i]] = value[i]

--- a/app/visualize/analysis/stmt/expr/expr_util/util.py
+++ b/app/visualize/analysis/stmt/expr/expr_util/util.py
@@ -2,7 +2,7 @@ import re
 
 
 def replace_word(expression, original_word, new_word):
-    pattern = rf'\b{original_word}\b'
+    pattern = rf"\b{original_word}\b"
     replaced_expression = re.sub(pattern, str(new_word), expression)
     return replaced_expression
 
@@ -15,8 +15,7 @@ def transpose_with_last_fill(expressions):
     transposed_values = []
     for i in range(max_length):
         current_list = list(
-            sublist[i] if isinstance(sublist, list) and i < len(sublist) else sublist[-1]
-            for sublist in expressions
+            sublist[i] if isinstance(sublist, list) and i < len(sublist) else sublist[-1] for sublist in expressions
         )
         transposed_values.append(current_list)
 

--- a/app/visualize/analysis/stmt/expr/parser/name_expr.py
+++ b/app/visualize/analysis/stmt/expr/parser/name_expr.py
@@ -26,7 +26,7 @@ class NameExpr:
     @staticmethod
     def _get_identifier_value(identifier_name, elem_manager: CodeElementManager):
         try:
-            return elem_manager.get_variable_value(name=identifier_name)
+            return elem_manager.get_element(name=identifier_name)
         except NameError as e:
             print("#error:", e)
 

--- a/app/visualize/analysis/stmt/model/for_stmt_obj.py
+++ b/app/visualize/analysis/stmt/model/for_stmt_obj.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+from app.visualize.analysis.stmt.expr.model.expr_obj import ExprObj
+
+
+@dataclass
+class ForStmtObj:
+    target: ExprObj
+    condition: ExprObj
+    type: str = "for"

--- a/app/visualize/analysis/stmt/model/for_stmt_obj.py
+++ b/app/visualize/analysis/stmt/model/for_stmt_obj.py
@@ -5,6 +5,6 @@ from app.visualize.analysis.stmt.expr.model.expr_obj import ExprObj
 
 @dataclass
 class ForStmtObj:
-    target: ExprObj
+    init_value: ExprObj
     condition: ExprObj
     type: str = "for"

--- a/app/visualize/analysis/stmt/parser/for_stmt.py
+++ b/app/visualize/analysis/stmt/parser/for_stmt.py
@@ -7,11 +7,12 @@ from app.visualize.analysis.stmt.model.for_stmt_obj import ForStmtObj
 
 class ForStmt:
     @staticmethod
-    def parse(target: ast, iter: ast, elem_manager: CodeElementManager):
-        target_obj = ForStmt._get_target_name(target, elem_manager)
+    def parse(target: ast.Name, iter: ast.Call, elem_manager: CodeElementManager):
+        # init Value
+        init_value_obj = ForStmt._get_target_name(target, elem_manager)
         condition_obj = ForStmt._get_condition_obj(iter, elem_manager)
 
-        return ForStmtObj(target=target_obj, condition=condition_obj)
+        return ForStmtObj(init_value=init_value_obj, condition=condition_obj)
 
     @staticmethod
     def _get_target_name(target, elem_manager: CodeElementManager):

--- a/app/visualize/analysis/stmt/parser/for_stmt.py
+++ b/app/visualize/analysis/stmt/parser/for_stmt.py
@@ -2,15 +2,16 @@ import ast
 
 from app.visualize.analysis.element_manager import CodeElementManager
 from app.visualize.analysis.stmt.expr.expr_traveler import ExprTraveler
+from app.visualize.analysis.stmt.model.for_stmt_obj import ForStmtObj
 
 
 class ForStmt:
     @staticmethod
     def parse(target: ast, iter: ast, elem_manager: CodeElementManager):
-        target_name = ForStmt._get_target_name(target, elem_manager)
-        condition_dict = ForStmt._get_condition_obj(iter, elem_manager)
+        target_obj = ForStmt._get_target_name(target, elem_manager)
+        condition_obj = ForStmt._get_condition_obj(iter, elem_manager)
 
-        return {"target": target_name, "condition_dict": condition_dict}
+        return ForStmtObj(target=target_obj, condition=condition_obj)
 
     @staticmethod
     def _get_target_name(target, elem_manager: CodeElementManager):

--- a/app/visualize/analysis/stmt/stmt_traveler.py
+++ b/app/visualize/analysis/stmt/stmt_traveler.py
@@ -11,11 +11,11 @@ class StmtTraveler:
     @staticmethod
     def for_travel(node: ast.For, elem_manager: CodeElementManager):
         # parse condition
-        condition_obj = ForStmt.parse(node.target, node.iter, elem_manager)
+        for_stmt_obj = ForStmt.parse(node.target, node.iter, elem_manager)
         # parse body
-        body_odjs = StmtTraveler._for_body_travel(node, elem_manager, condition_obj)
+        body_odjs = StmtTraveler._for_body_travel(node, elem_manager, for_stmt_obj.condition)
 
-        return {"condition": condition_obj, "body": body_odjs}
+        return for_stmt_obj
 
     @staticmethod
     def _for_body_travel(node: ast, elem_manager, condition_obj):

--- a/app/visualize/code_analyzer.py
+++ b/app/visualize/code_analyzer.py
@@ -1,14 +1,39 @@
 import ast
 
-from app.analysis.generator.body_generator import BodyGenerator
 from app.visualize.analysis.element_manager import CodeElementManager
+from app.visualize.analysis.stmt.stmt_traveler import StmtTraveler
 
 
 # TODO 이름 수정
-class CodeAnalyzer:
+class CodeVisualizer:
 
-    def __init__(self, elem_manager: CodeElementManager):
-        self.elem_manager = elem_manager
+    def __init__(self, source_code):
+        self._parsed_node = ast.parse(source_code)
+        self._elem_manager = CodeElementManager()
 
-    def visualize_code(self, parsed_ast: ast.Module):
-        return BodyGenerator.generate(parsed_ast.body, self.elem_manager)
+    def visualize_code(self):
+        analysis_objs = self._analysis_parsed_node()
+        # TODO: 시각화 노드 리스트 생성
+        return analysis_objs
+
+    def _analysis_parsed_node(self):
+        self._elem_manager.increase_depth()
+        steps = []
+
+        for node in self._parsed_node.body:
+            if isinstance(node, ast.Assign):
+                pass
+
+            elif isinstance(node, ast.For):
+                for_vizs = StmtTraveler.for_travel(node, self._elem_manager)
+                steps.extend(for_vizs)
+
+            elif isinstance(node, ast.Expr):
+                pass
+
+            else:
+                raise TypeError(f"지원하지 않는 노드 타입입니다.: {type(node)}")
+
+        self._elem_manager.decrease_depth()
+
+        return steps

--- a/app/visualize/generator/model/models.py
+++ b/app/visualize/generator/model/models.py
@@ -7,10 +7,10 @@ class AssignViz:
     type: str = "assignViz"
 
 
-'''
+"""
     @ list: Variable 리스트
-    @ type: 타입
-'''
+    @ type: 타입````
+"""
 
 
 @dataclass(frozen=True)
@@ -20,11 +20,11 @@ class Variable:
     name: str
 
 
-'''
+"""
     @ depth: 깊이
     @ expr: 변수에 들어갈 표현식
     @ name: 변수 이름
-'''
+"""
 
 
 @dataclass
@@ -42,7 +42,7 @@ class ConditionViz:
         if self.start == self.cur:
             return list(self.__dict__.keys())
 
-        return ['cur']
+        return ["cur"]
 
 
 @dataclass(frozen=True)
@@ -54,12 +54,12 @@ class ForViz:
     type: str = "for"
 
 
-'''
+"""
     @ id: 식별값
     @ depth: 깊이
     @ condition: 조건절
     @ type : 타입
-'''
+"""
 
 
 @dataclass(frozen=True)
@@ -72,10 +72,10 @@ class PrintViz:
     type: str = "print"
 
 
-'''
+"""
     @ id: 식별값
     @ depth: 깊이
     @ name: 변수 이름
     @ value: 변수 값
 
-'''
+"""

--- a/tests/visualize/analysis/stmt/parser/test_for_stmt.py
+++ b/tests/visualize/analysis/stmt/parser/test_for_stmt.py
@@ -17,6 +17,57 @@ def create_ast():
     return _create_ast_node
 
 
+@pytest.mark.parametrize(
+    "code, expect",
+    [
+        (
+            """for i in range(3): \n    pass""",
+            ExprObj(
+                type="name",
+                value="i",
+                expressions=["i"],
+            ),
+        ),
+        (
+            """for a in range(3): \n    pass""",
+            ExprObj(
+                type="name",
+                value="a",
+                expressions=["a"],
+            ),
+        ),
+    ],
+)
+def test__get_target_name(create_ast, elem_manager, code, expect):
+    # target 노드를 받아서 변수 이름을 반환하는지 테스트
+    target_node = create_ast(code).target
+
+    actual = ForStmt._get_target_name(target_node, elem_manager)
+    assert actual == expect
+
+
+@pytest.mark.parametrize(
+    "code, expect",
+    [
+        (
+            """for [a] in range(10): \n    pass""",
+            ExprObj(
+                type="name",
+                value="i",
+                expressions=["i"],
+            ),
+        ),
+    ],
+)
+def test__get_target_name_fail(create_ast, elem_manager, code, expect):
+    # target 노드를 받아서 변수 이름을 반환하는지 테스트
+    target_node = create_ast(code).target
+
+    # 예외가 터지면 통과, 안터지면 실패
+    with pytest.raises(TypeError, match=r"\[ForParser\]:  .*는 잘못된 타입입니다."):
+        ForStmt._get_target_name(target_node, elem_manager)
+
+
 # TODO 함수마다 parser를 추가하는 방향 고민
 @pytest.mark.parametrize(
     "code, expect",
@@ -31,7 +82,7 @@ def create_ast():
         )
     ],
 )
-def test_get_condition_value_list(create_ast, elem_manager, code, expect):
+def test_get_condition_obj(create_ast, elem_manager, code, expect):
     # iter 노드를 받아서 range 함수의 파라미터를 반환하는지 테스트
     iter_node = create_ast(code).iter
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #97 

## 📝 작업 내용

- codeAnaysis를 codeVisulize로 변경하고 시각화 시작하는 코드 수정
- for문 파싱을 ForStmt를 호출하여 실행하도록 변경


