### PR TITLE
[#100] refactor: Expr Stmt 로직 분리

### DIFF
--- a/app/route.py
+++ b/app/route.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from app.visualize.analysis.element_manager import CodeElementManager
-from app.visualize.code_analyzer import CodeVisualizer
+from app.visualize.code_visualizer import CodeVisualizer
 
 app = FastAPI()
 

--- a/app/visualize/analysis/stmt/expr/expr_traveler.py
+++ b/app/visualize/analysis/stmt/expr/expr_traveler.py
@@ -15,7 +15,7 @@ class ExprTraveler:
             left = ExprTraveler.binop_travel(node.left, elem_manager)
             right = ExprTraveler.binop_travel(node.right, elem_manager)
             op = node.op
-            return BinopExpr.parse(left, right, op, elem_manager)
+            return BinopExpr.parse(left, right, op)
 
         elif isinstance(node, ast.Name):
             return ExprTraveler.name_travel(node, elem_manager)
@@ -42,7 +42,7 @@ class ExprTraveler:
     @staticmethod
     def _get_func_name(node: ast, elem_manager: CodeElementManager):
         if isinstance(node, ast.Name):
-            return ExprTraveler.name_travel(node, elem_manager)
+            return node.id
 
         elif isinstance(node, ast.Attribute):
             raise NotImplementedError(f"[call_travel] {type(node)}정의되지 않았습니다.")

--- a/app/visualize/analysis/stmt/model/expr_stmt_obj.py
+++ b/app/visualize/analysis/stmt/model/expr_stmt_obj.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ExprStmtObj:
+    type: str
+    value: Any
+    expressions: list[str]

--- a/app/visualize/analysis/stmt/parser/assign_stmt.py
+++ b/app/visualize/analysis/stmt/parser/assign_stmt.py
@@ -14,7 +14,7 @@ class AssignStmt:
 
         AssignStmt._assign_value_to_target(target_names, expr_obj.value, elem_manager)
 
-        return AssignStmt._create_assign_obj(target_names, expr_obj.value)
+        return AssignStmt._create_assign_obj(target_names, expr_obj.expressions)
 
     @staticmethod
     def _get_target_names(node: ast, elem_manager: CodeElementManager):
@@ -43,7 +43,7 @@ class AssignStmt:
     @staticmethod
     def _assign_value_to_target(target_names: list[str], value, elem_manager: CodeElementManager):
         for target_name in target_names:
-            elem_manager.add_variable_value(target_name, value)
+            elem_manager.set_element(target_name, value)
 
     @staticmethod
     def _create_assign_obj(target_names: list[str], value_expressions: list[str]):

--- a/app/visualize/analysis/stmt/parser/expr_stmt.py
+++ b/app/visualize/analysis/stmt/parser/expr_stmt.py
@@ -7,20 +7,29 @@ from app.visualize.analysis.stmt.expr.expr_traveler import ExprTraveler
 class ExprStmt:
 
     @staticmethod
-    def parse(expr_value: ast, elem_manager: CodeElementManager):
-        return ExprStmt._get_parse_value(expr_value, elem_manager)
+    def parse(node: ast.Expr, elem_manager: CodeElementManager):
+        return ExprStmt._get_expr_obj(node.value, elem_manager)
 
     @staticmethod
-    def _get_parse_value(expr_value: ast, elem_manager: CodeElementManager):
-        if isinstance(expr_value, ast.Name):
-            return
-        elif isinstance(expr_value, ast.Constant):
-            return
-        elif isinstance(expr_value, ast.BinOp):
-            return
-        elif isinstance(expr_value, ast.Call):
-            return ExprTraveler.call_travel(expr_value, elem_manager)
-        elif isinstance(expr_value, ast.Lambda):
-            return
+    def _get_expr_obj(node_value: ast, elem_manager: CodeElementManager):
+        if isinstance(node_value, ast.Name):
+            name_obj = ExprTraveler.name_travel(node_value, elem_manager)
+            return name_obj
+
+        elif isinstance(node_value, ast.Constant):
+            constant_obj = ExprTraveler.constant_travel(node_value)
+            return constant_obj
+
+        elif isinstance(node_value, ast.BinOp):
+            binop_obj = ExprTraveler.binop_travel(node_value, elem_manager)
+            return binop_obj
+
+        elif isinstance(node_value, ast.Call):
+            call_obj = ExprTraveler.call_travel(node_value, elem_manager)
+            return call_obj
+
+        elif isinstance(node_value, ast.Lambda):
+            raise NotImplementedError(f"[ExprParser]:{type(node_value)}는 정의되지 않았습니다.")
+
         else:
-            raise TypeError(f"[ExprParser]:{type(expr_value)}는 정의되지 않았습니다.")
+            raise TypeError(f"[ExprParser]:{type(node_value)}는 지원하지 않습니다.")

--- a/app/visualize/analysis/stmt/parser/expr_stmt.py
+++ b/app/visualize/analysis/stmt/parser/expr_stmt.py
@@ -2,13 +2,15 @@ import ast
 
 from app.visualize.analysis.element_manager import CodeElementManager
 from app.visualize.analysis.stmt.expr.expr_traveler import ExprTraveler
+from app.visualize.analysis.stmt.model.expr_stmt_obj import ExprStmtObj
 
 
 class ExprStmt:
 
     @staticmethod
     def parse(node: ast.Expr, elem_manager: CodeElementManager):
-        return ExprStmt._get_expr_obj(node.value, elem_manager)
+        expr_obj = ExprStmt._get_expr_obj(node.value, elem_manager)
+        return ExprStmtObj(type=expr_obj.type, value=expr_obj.value, expressions=expr_obj.expressions)
 
     @staticmethod
     def _get_expr_obj(node_value: ast, elem_manager: CodeElementManager):

--- a/app/visualize/analysis/stmt/stmt_traveler.py
+++ b/app/visualize/analysis/stmt/stmt_traveler.py
@@ -41,7 +41,7 @@ class StmtTraveler:
 
     @staticmethod
     def expr_travel(node: ast.Expr, elem_manager: CodeElementManager):
-        return ExprStmt.parse(node.value, elem_manager)
+        return ExprStmt.parse(node, elem_manager)
 
     @staticmethod
     def _internal_travel(node: ast, elem_manager: CodeElementManager):

--- a/app/visualize/code_visualizer.py
+++ b/app/visualize/code_visualizer.py
@@ -22,14 +22,17 @@ class CodeVisualizer:
 
         for node in self._parsed_node.body:
             if isinstance(node, ast.Assign):
-                pass
+                assign_obj = StmtTraveler.assign_travel(node, self._elem_manager)
+                # TODO:Assing_obj를 리스트가 아닌객체로 변경하고, extend -> append로 변경
+                steps.extend(assign_obj)
 
             elif isinstance(node, ast.For):
                 for_vizs = StmtTraveler.for_travel(node, self._elem_manager)
-                steps.extend(for_vizs)
+                steps.append(for_vizs)
 
             elif isinstance(node, ast.Expr):
-                pass
+                expr_obj = StmtTraveler.expr_travel(node, self._elem_manager)
+                steps.append(expr_obj)
 
             else:
                 raise TypeError(f"지원하지 않는 노드 타입입니다.: {type(node)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,5 +8,5 @@ from app.visualize.analysis.element_manager import CodeElementManager
 @pytest.fixture
 def elem_manager():
     mock = MagicMock(spec=CodeElementManager)
-    mock.get_variable_value.return_value = 10
+    mock.set_element.return_value = 10
     return mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import ast
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,3 +11,13 @@ def elem_manager():
     mock = MagicMock(spec=CodeElementManager)
     mock.get_element.return_value = 10
     return mock
+
+
+@pytest.fixture
+def create_ast():
+    # 코드를 ast 노드로 변환하는 함수를 반환
+    def _create_ast_node(code):
+        # ast.Call 반환
+        return ast.parse(code).body[0]
+
+    return _create_ast_node

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,5 +8,5 @@ from app.visualize.analysis.element_manager import CodeElementManager
 @pytest.fixture
 def elem_manager():
     mock = MagicMock(spec=CodeElementManager)
-    mock.set_element.return_value = 10
+    mock.get_element.return_value = 10
     return mock

--- a/tests/visualize/analysis/stmt/parser/test_expr_stmt.py
+++ b/tests/visualize/analysis/stmt/parser/test_expr_stmt.py
@@ -1,0 +1,69 @@
+import ast
+
+import pytest
+
+from app.visualize.analysis.stmt.expr.model.expr_obj import ExprObj
+from app.visualize.analysis.stmt.parser.expr_stmt import ExprStmt
+
+
+@pytest.fixture
+def create_ast():
+    # 코드를 ast 노드로 변환하는 함수를 반환
+    def _create_ast_node(code):
+        # ast.Call 반환
+        return ast.parse(code).body[0]
+
+    return _create_ast_node
+
+
+@pytest.mark.parametrize(
+    "code, expect",
+    [
+        (
+            """a""",
+            ExprObj(
+                type="name",
+                value=10,
+                expressions=["a", "10"],
+            ),
+        ),
+        (
+            """20""",
+            ExprObj(
+                type="constant",
+                value=20,
+                expressions=["20"],
+            ),
+        ),
+        (
+            """10 + 20""",
+            ExprObj(
+                type="binop",
+                value=30,
+                expressions=["10 + 20", "30"],
+            ),
+        ),
+        (
+            """print(a+2)""",
+            ExprObj(
+                type="print",
+                value="12\n",
+                expressions=["a + 2\n", "10 + 2\n", "12\n"],
+            ),
+        ),
+        (
+            """print(a)""",
+            ExprObj(
+                type="print",
+                value="10\n",
+                expressions=["a\n", "10\n"],
+            ),
+        ),
+    ],
+)
+def test__get_expr_obj(create_ast, elem_manager, code, expect):
+    # expr 노드를 받아서 변수 이름을 반환하는지 통합테스트
+    expr_node = create_ast(code)
+
+    actual = ExprStmt._get_expr_obj(expr_node.value, elem_manager)
+    assert actual == expect

--- a/tests/visualize/analysis/stmt/parser/test_expr_stmt.py
+++ b/tests/visualize/analysis/stmt/parser/test_expr_stmt.py
@@ -17,10 +17,10 @@ def create_ast():
 
 
 @pytest.mark.parametrize(
-    "code, expect",
+    "node, expect",
     [
         (
-            """a""",
+            ast.Name("a", ast.Load()),
             ExprObj(
                 type="name",
                 value=10,
@@ -28,7 +28,7 @@ def create_ast():
             ),
         ),
         (
-            """20""",
+            ast.Constant(20),
             ExprObj(
                 type="constant",
                 value=20,
@@ -36,7 +36,7 @@ def create_ast():
             ),
         ),
         (
-            """10 + 20""",
+            ast.BinOp(ast.Constant(10), ast.Add(), ast.Constant(20)),
             ExprObj(
                 type="binop",
                 value=30,
@@ -44,7 +44,11 @@ def create_ast():
             ),
         ),
         (
-            """print(a+2)""",
+            ast.Call(
+                func=ast.Name("print", ast.Load()),
+                args=[ast.BinOp(ast.Name("a", ast.Load()), ast.Add(), ast.Constant(2))],
+                keywords=[],
+            ),
             ExprObj(
                 type="print",
                 value="12\n",
@@ -52,7 +56,11 @@ def create_ast():
             ),
         ),
         (
-            """print(a)""",
+            ast.Call(
+                func=ast.Name("print", ast.Load()),
+                args=[ast.Name("a", ast.Load())],
+                keywords=[],
+            ),
             ExprObj(
                 type="print",
                 value="10\n",
@@ -61,9 +69,8 @@ def create_ast():
         ),
     ],
 )
-def test__get_expr_obj(create_ast, elem_manager, code, expect):
+def test__get_expr_obj(elem_manager, node, expect):
     # expr 노드를 받아서 변수 이름을 반환하는지 통합테스트
-    expr_node = create_ast(code)
 
-    actual = ExprStmt._get_expr_obj(expr_node.value, elem_manager)
+    actual = ExprStmt._get_expr_obj(node, elem_manager)
     assert actual == expect


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #100 

## 📝 작업 내용

- ast.Expr를 파싱하는 ExprStmt의 기능을 추가했습니다.

### 스크린샷 (선택)
**실행 샘플 코드**
![image](https://github.com/Co-due/Code-Analysis-Server/assets/88374384/668f8c00-90ee-4aee-860b-be7288c7c4d7)
**출력 결과**
![image](https://github.com/Co-due/Code-Analysis-Server/assets/88374384/3b499541-14bd-45cc-b347-a2f01d5be8de)


## 💬 리뷰 요구사항(선택)

- Expr Stmt가 반환하는 데이터가 ExprObj 입니다. 따로 ExprStmtObj를 만들어야 할까요? 클래스의 이름만 달라질 뿐 저장되는 데이터는 같을 것 같아서 따로 추가하지는 않았습니다.


