### PR TITLE
[#149]Test: expr들의 parse함수에 mock 처리 추가

### DIFF
--- a/app/visualize/analysis/stmt/parser/expr/expr_traveler.py
+++ b/app/visualize/analysis/stmt/parser/expr/expr_traveler.py
@@ -54,7 +54,7 @@ class ExprTraveler:
 
     @staticmethod
     def _name_travel(node: ast.Name, elem_container: ElementContainer):
-        return NameExpr.parse(node.ctx, node.id, elem_container)
+        return NameExpr.parse(node, elem_container)
 
     @staticmethod
     def _constant_travel(node: ast.Constant):

--- a/app/visualize/analysis/stmt/parser/expr/parser/call_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/call_expr.py
@@ -10,13 +10,13 @@ class CallExpr:
     def parse(func_name: str, args: list[ExprObj], keyword_arg_dict: dict):
 
         if func_name == "print":
-            end_keyword, print_expressions = CallExpr._print_parse(args, keyword_arg_dict)
-            return PrintObj(value=print_expressions[-1] + end_keyword, expressions=print_expressions)
+            value, expressions = CallExpr._print_parse(args, keyword_arg_dict)
+            return PrintObj(value=value, expressions=expressions)
 
         elif func_name == "range":
-            range_iter, range_expressions = CallExpr._range_parse(args)
+            value, expressions = CallExpr._range_parse(args)
 
-            return RangeObj(value=range_iter, expressions=range_expressions)
+            return RangeObj(value=value, expressions=expressions)
 
         else:
             raise TypeError(f"[CallParser]: {func_name} is not defined.")
@@ -36,7 +36,9 @@ class CallExpr:
             str_expression = default_keyword["sep"].join(expressions)
             print_expressions.append(str_expression)
 
-        return default_keyword["end"], tuple(print_expressions)
+        value = print_expressions[-1] + default_keyword["end"]
+
+        return value, tuple(print_expressions)
 
     # print 함수의 키워드 파싱 : end, sep만 지원 Todo. file, flush
     @staticmethod

--- a/app/visualize/analysis/stmt/parser/expr/parser/list_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/list_expr.py
@@ -7,7 +7,7 @@ class ListExpr:
     @staticmethod
     def parse(elts: list[ExprObj]):
         value = ListExpr._get_value(elts)
-        expressions = ListExpr._concat_expression(elts)
+        expressions = ListExpr._concat_expressions(elts)
 
         return ListObj(value=value, expressions=expressions)
 
@@ -16,7 +16,7 @@ class ListExpr:
         return [elt.value for elt in elts]
 
     @staticmethod
-    def _concat_expression(elts: list[ExprObj]):
+    def _concat_expressions(elts: list[ExprObj]):
         elts_expression_lists = [elt.expressions for elt in elts]
 
         # [("a + 1", "10 + 1", "11"), ("20",)] -> [("a + 1", "20"), ("10 + 1", "20"), ("11", "20")]

--- a/app/visualize/analysis/stmt/parser/expr/parser/name_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/name_expr.py
@@ -7,20 +7,20 @@ from app.visualize.analysis.stmt.parser.expr.models.expr_obj import NameObj
 class NameExpr:
 
     @staticmethod
-    def parse(ctx: ast, identifier_name, elem_container: ElementContainer):
-        if isinstance(ctx, ast.Store):
-            return NameObj(value=identifier_name, expressions=(identifier_name,))
+    def parse(node: ast.Name, elem_container: ElementContainer):
+        if isinstance(node.ctx, ast.Store):
+            return NameObj(value=node.id, expressions=(node.id,))
 
-        elif isinstance(ctx, ast.Load):
-            value = NameExpr._get_identifier_value(identifier_name, elem_container)
-            expressions = NameExpr._create_expressions(identifier_name, value)
+        elif isinstance(node.ctx, ast.Load):
+            value = NameExpr._get_identifier_value(node.id, elem_container)
+            expressions = NameExpr._create_expressions(node.id, value)
             return NameObj(value=value, expressions=expressions)
 
-        elif isinstance(ctx, ast.Del):
-            raise NotImplementedError(f"Unsupported node type: {type(ctx)}")
+        elif isinstance(node.ctx, ast.Del):
+            raise NotImplementedError(f"Unsupported node type: {type(node.ctx)}")
 
         else:
-            raise TypeError(f"[call_travel] {type(ctx)}는 잘못된 타입입니다.")
+            raise TypeError(f"[call_travel] {type(node.ctx)}는 잘못된 타입입니다.")
 
     # 변수의 값을 가져오는 함수
     @staticmethod

--- a/poetry.lock
+++ b/poetry.lock
@@ -864,6 +864,23 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1121,6 +1138,16 @@ files = [
     {file = "ujson-5.10.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0de4971a89a762398006e844ae394bd46991f7c385d7a6a3b93ba229e6dac17e"},
     {file = "ujson-5.10.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:e1402f0564a97d2a52310ae10a64d25bcef94f8dd643fcf5d310219d915484f7"},
     {file = "ujson-5.10.0.tar.gz", hash = "sha256:b3cd8f3c5d8c7738257f1018880444f7b7d9b66232c64649f562d7ba86ad4bc1"},
+]
+
+[[package]]
+name = "utils"
+version = "1.0.2"
+description = "A grab-bag of utility functions and objects"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "utils-1.0.2.tar.gz", hash = "sha256:f4d5157e27e9d434006b5b52a1ec951a34e53e7ecaa145d43a153ec452eb5d9e"},
 ]
 
 [[package]]
@@ -1383,4 +1410,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "24150504c65eebe52035885ea6fde576486898263d398cc6f52a285f56971a48"
+content-hash = "622c8967f99bcad28771759859e5d893f70ee98eb79de02463fdec70fd7e31be"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ uvloop = "0.19.0"
 watchfiles = "0.22.0"
 websockets = "12.0"
 pytest = ">=8.2.2,<8.3.0"
+pytest-mock = "^3.14.0"
+utils = "^1.0.2"
 
 [tool.black]
 line-length = 120

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_binop_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_binop_expr.py
@@ -46,9 +46,9 @@ def test_parse(mocker, left_obj: ExprObj, right_obj: ExprObj, op: ast, expected:
 
     result = BinopExpr.parse(left_obj, right_obj, op)
 
-    assert mock_calculate_value.call_count == 1
-    assert mock_create_expressions.call_count == 1
     assert result == expected
+    assert mock_calculate_value.call_once_with(left_obj.value, right_obj.value, op)
+    assert mock_create_expressions.call_once_with(left_obj.expressions, right_obj.expressions, op, expected.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_call_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_call_expr.py
@@ -13,53 +13,109 @@ from app.visualize.analysis.stmt.parser.expr.parser.call_expr import CallExpr
 
 
 @pytest.mark.parametrize(
-    "func_name, mock_value, mock_expressions",
+    "func_name, args, keyword_arg_dict, expected",
     [
-        pytest.param("print", "abc\n", ("abc",), id="print('abc'): success case"),
-        pytest.param("print", "****\n", ("'*' * 4", "'****'"), id="print('*' * 4): success case"),
-        pytest.param("print", "abc ", ("abc",), id="print('abc', end=' '): success case"),
-        pytest.param("print", "abc def\n", ("abc def",), id="print('abc', 'def'): success case"),
-        pytest.param("print", "abc-def\n", ("abc-def",), id="print('abc', 'def', sep='-'): success case"),
+        pytest.param(
+            "print",
+            [ConstantObj(value="abc", expressions=("abc",))],
+            {},
+            PrintObj(value="abc\n", expressions=("abc",)),
+            id="print('abc'): success case",
+        ),
+        pytest.param(
+            "print",
+            [BinopObj(value="'****'", expressions=("'*' * 4", "'****'"))],
+            {},
+            PrintObj(value="****\n", expressions=("'*' * 4", "'****'")),
+            id="print('*' * 4): success case",
+        ),
+        pytest.param(
+            "print",
+            [ConstantObj(value="abc", expressions=("abc",))],
+            {"end": " "},
+            PrintObj(value="abc ", expressions=("abc",)),
+            id="print('abc', end=' '): success case",
+        ),
+        pytest.param(
+            "print",
+            [ConstantObj(value="abc", expressions=("abc",)), ConstantObj(value="def", expressions=("def",))],
+            {},
+            PrintObj(value="abc def\n", expressions=("abc def",)),
+            id="print('abc', 'def'): success case",
+        ),
+        pytest.param(
+            "print",
+            [ConstantObj(value="abc", expressions=("abc",)), ConstantObj(value="def", expressions=("def",))],
+            {"sep": "-"},
+            PrintObj(value="abc-def\n", expressions=("abc-def",)),
+            id="print('abc', 'def', sep='-'): success case",
+        ),
+    ],
+)
+def test_parse_case_print(mocker, func_name: str, args: list[ExprObj], keyword_arg_dict: dict, expected: PrintObj):
+    mock_print_parse = mocker.patch.object(
+        CallExpr,
+        "_print_parse",
+        return_value=(expected.value, expected.expressions),
+    )
+    result = CallExpr.parse(func_name, args, keyword_arg_dict)
+
+    assert isinstance(result, PrintObj)
+    assert mock_print_parse.called_once_with(args, keyword_arg_dict)
+
+
+@pytest.mark.parametrize(
+    "func_name, args, expected",
+    [
         pytest.param(
             "range",
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            (RangeExpression(start="0", end="10", step="1")),
+            [ConstantObj(value=10, expressions=("10",))],
+            RangeObj(
+                value=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), expressions=(RangeExpression(start="0", end="10", step="1"),)
+            ),
             id="range(10): success case",
         ),
         pytest.param(
             "range",
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            (RangeExpression(start="0", end="a", step="1"), RangeExpression(start="0", end="10", step="1")),
+            [NameObj(value=10, expressions=("a", "10"))],
+            RangeObj(
+                value=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+                expressions=(
+                    RangeExpression(start="0", end="a", step="1"),
+                    RangeExpression(start="0", end="10", step="1"),
+                ),
+            ),
             id="range(a): success case",
         ),
         pytest.param(
             "range",
-            [2, 3, 4, 5, 6, 7, 8, 9],
-            (RangeExpression(start="2", end="10", step="1")),
+            [ConstantObj(value=2, expressions=("2",)), ConstantObj(value=10, expressions=("10",))],
+            RangeObj(value=(2, 3, 4, 5, 6, 7, 8, 9), expressions=(RangeExpression(start="2", end="10", step="1"),)),
             id="range(2, 10): success case",
         ),
         pytest.param(
             "range",
-            [2, 4, 6, 8],
-            (RangeExpression(start="2", end="10", step="2")),
+            [
+                ConstantObj(value=2, expressions=("2",)),
+                ConstantObj(value=10, expressions=("10",)),
+                ConstantObj(value=2, expressions=("2",)),
+            ],
+            RangeObj(value=(2, 4, 6, 8), expressions=(RangeExpression(start="2", end="10", step="1"),)),
             id="range(2, 10, 2): success case",
         ),
     ],
 )
-def test_parse(mocker, func_name: str, mock_value, mock_expressions):
-    mocker.patch(
-        "app.visualize.analysis.stmt.parser.expr.parser.call_expr.CallExpr._print_parse",
-        return_value=(mock_value, mock_expressions),
+def test_parse_case_range(mocker, func_name: str, args: list[ExprObj], expected: RangeObj):
+    keyword_arg_dict = {}
+    mock_range_parse = mocker.patch.object(
+        CallExpr,
+        "_range_parse",
+        return_value=(expected.value, expected.expressions),
     )
-    mocker.patch(
-        "app.visualize.analysis.stmt.parser.expr.parser.call_expr.CallExpr._range_parse",
-        return_value=(mock_value, mock_expressions),
-    )
-    result = CallExpr.parse(func_name, [mocker.MagicMock(spec=ExprObj)], {})
+    result = CallExpr.parse(func_name, args, keyword_arg_dict)
 
-    assert isinstance(result, PrintObj) or isinstance(result, RangeObj)
-    assert result.value == mock_value
-    assert result.expressions == mock_expressions
+    assert isinstance(result, RangeObj)
+    assert mock_range_parse.called_once_with(args, keyword_arg_dict)
 
 
 @pytest.mark.parametrize(

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_constant_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_constant_expr.py
@@ -7,21 +7,38 @@ from app.visualize.analysis.stmt.parser.expr.parser.constant_expr import Constan
 
 
 @pytest.mark.parametrize(
-    "mock_value, expected",
+    "node, expected",
     [
-        pytest.param(10, ConstantObj(value=10, expressions=("10",)), id="10: success case"),
-        pytest.param("Hello", ConstantObj(value="Hello", expressions=("'Hello'",)), id="'Hello': success case"),
-        pytest.param("World", ConstantObj(value="World", expressions=("'World'",)), id="'World': success case"),
+        pytest.param(ast.Constant(value=10), ConstantObj(value=10, expressions=("10",)), id="10: success case"),
+        pytest.param(
+            ast.Constant(value="Hello"),
+            ConstantObj(value="Hello", expressions=("'Hello'",)),
+            id="'Hello': success case",
+        ),
+        pytest.param(
+            ast.Constant(value="World"),
+            ConstantObj(value="World", expressions=("'World'",)),
+            id="'World': success case",
+        ),
     ],
 )
-def test_parse(mocker, mock_value, expected):
-    mocker.patch(
-        "app.visualize.analysis.stmt.parser.expr.parser.constant_expr.ConstantExpr._get_literal",
-        return_value=mock_value,
+def test_parse(mocker, node: ast.Constant, expected: ConstantObj):
+    mock_get_literal = mocker.patch.object(
+        ConstantExpr,
+        "_get_literal",
+        return_value=expected.value,
     )
-    result = ConstantExpr.parse(mocker.MagicMock(spec=ast.Constant))
+
+    mock_create_expressions = mocker.patch.object(
+        ConstantExpr,
+        "_create_expressions",
+        return_value=expected.expressions,
+    )
+    result = ConstantExpr.parse(node)
 
     assert result == expected
+    assert mock_get_literal.called_once_with(node)
+    assert mock_create_expressions.called_once_with(expected.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_constant_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_constant_expr.py
@@ -7,16 +7,19 @@ from app.visualize.analysis.stmt.parser.expr.parser.constant_expr import Constan
 
 
 @pytest.mark.parametrize(
-    "node, expected",
+    "mock_value, expected",
     [
-        pytest.param(ast.Constant(value=10), ConstantObj(value=10, expressions=("10",)), id="10: success case"),
-        pytest.param(
-            ast.Constant(value="abc"), ConstantObj(value="abc", expressions=("'abc'",)), id="'abc': success case"
-        ),
+        pytest.param(10, ConstantObj(value=10, expressions=("10",)), id="10: success case"),
+        pytest.param("Hello", ConstantObj(value="Hello", expressions=("'Hello'",)), id="'Hello': success case"),
+        pytest.param("World", ConstantObj(value="World", expressions=("'World'",)), id="'World': success case"),
     ],
 )
-def test_parse(node: ast.Constant, expected):
-    result = ConstantExpr.parse(node)
+def test_parse(mocker, mock_value, expected):
+    mocker.patch(
+        "app.visualize.analysis.stmt.parser.expr.parser.constant_expr.ConstantExpr._get_literal",
+        return_value=mock_value,
+    )
+    result = ConstantExpr.parse(mocker.MagicMock(spec=ast.Constant))
 
     assert result == expected
 
@@ -24,8 +27,9 @@ def test_parse(node: ast.Constant, expected):
 @pytest.mark.parametrize(
     "node, expected",
     [
-        pytest.param(ast.Constant(value=10), 10),
-        pytest.param(ast.Constant(value="abc"), "abc", id="'abc': success case"),
+        pytest.param(ast.Constant(value=10), 10, id="10: success case"),
+        pytest.param(ast.Constant(value="Hello"), "Hello", id="'Hello': success case"),
+        pytest.param(ast.Constant(value="World"), "World", id="'World': success case"),
     ],
 )
 def test_get_literal(node: ast.Constant, expected):
@@ -36,7 +40,11 @@ def test_get_literal(node: ast.Constant, expected):
 
 @pytest.mark.parametrize(
     "value, expected",
-    [pytest.param(10, ("10",), id="10: success case"), pytest.param("abc", ("'abc'",), id="'abc': success case")],
+    [
+        pytest.param(10, ("10",), id="10: success case"),
+        pytest.param("Hello", ("'Hello'",), id="'Hello': success case"),
+        pytest.param("World", ("'World'",), id="'World': success case"),
+    ],
 )
 def test_create_expressions(value, expected):
     result = ConstantExpr._create_expressions(value)

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_list_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_list_expr.py
@@ -1,40 +1,90 @@
-# _*_ coding: utf-8 _*_
-
 import pytest
 
-from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ListObj, ConstantObj, BinopObj, NameObj, ExprObj
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ListObj, ExprObj
 from app.visualize.analysis.stmt.parser.expr.parser.list_expr import ListExpr
 
 
 @pytest.mark.parametrize(
-    "elts, expected",
+    "value, expressions",
     [
+        pytest.param([10, 20], ("[10,20]",), id="[10, 20]: success case"),
         pytest.param(
-            [ConstantObj(value=10, expressions=("10",)), ConstantObj(value=20, expressions=("20",))],
-            ListObj(value=[10, 20], expressions=("[10,20]",)),
-            id="[10, 20]: success case",
-        ),
-        pytest.param(
-            [BinopObj(value=11, expressions=("a + 1", "10 + 1", "11")), ConstantObj(value=20, expressions=("20",))],
-            ListObj(value=[11, 20], expressions=("[a + 1,20]", "[10 + 1,20]", "[11,20]")),
+            [11, 20],
+            ("[a + 1,20]", "[10 + 1,20]", "[11,20]"),
             id="[a + 1, 20]: success case",
         ),
         pytest.param(
-            [
-                ConstantObj(value="Hello", expressions=("'Hello'",)),
-                ConstantObj(value="World", expressions=("'World'",)),
-            ],
-            ListObj(value=["Hello", "World"], expressions=("['Hello','World']",)),
+            ["Hello", "World"],
+            ("['Hello','World']",),
             id='["Hello", "World"]: success case',
         ),
         pytest.param(
-            [NameObj(value="a", expressions=("a",)), NameObj(value="b", expressions=("b",))],
-            ListObj(value=["a", "b"], expressions=("[a,b]",)),
+            ["a", "b"],
+            ("[a,b]",),
             id="[a, b] success case",
         ),
     ],
 )
-def test_parse(elts: list[ExprObj], expected):
-    result = ListExpr.parse(elts)
+def test_parse(mocker, value, expressions):
+    # _get_value mocking
+    mocker.patch("app.visualize.analysis.stmt.parser.expr.parser.list_expr.ListExpr._get_value", return_value=value)
+    # _concat_expression mocking
+    mocker.patch(
+        "app.visualize.analysis.stmt.parser.expr.parser.list_expr.ListExpr._concat_expression",
+        return_value=expressions,
+    )
+
+    result = ListExpr.parse([mocker.MagicMock(spec=ExprObj) for _ in range(len(value))])
+
+    assert isinstance(result, ListObj)
+    assert result.value == value
+    assert result.expressions == expressions
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param([10, 20], id="[10, 20]: success case"),
+        pytest.param([11, 20], id="[11, 20]: success case"),
+        pytest.param(["Hello", "World"], id='["Hello", "World"]: success case'),
+        pytest.param(["a", "b"], id="[a, b] success case"),
+    ],
+)
+def test_get_value(mocker, value):
+    # elts 생성
+    elts = [mocker.MagicMock(spec=ExprObj, value=v) for v in value]
+    result = ListExpr._get_value(elts)
+
+    assert isinstance(result, list)
+    assert result == value
+
+
+@pytest.mark.parametrize(
+    "expressions, transposed_expression_lists_result, expected",
+    [
+        pytest.param([("10",), ("20",)], [("10", "20")], ("[10,20]",), id="[10, 20]: success case"),
+        pytest.param(
+            [("a", "10"), ("20",), ("30",)],
+            [("a", "20", "30"), ("10", "20", "30")],
+            ("[a,20,30]", "[10,20,30]"),
+            id="[a, 20, 30]: success case",
+        ),
+        pytest.param(
+            [("a + 1", "10 + 1", "11"), ("20",)],
+            [("a + 1", "20"), ("10 + 1", "20"), ("11", "20")],
+            ("[a + 1,20]", "[10 + 1,20]", "[11,20]"),
+            id="[a + 1, 20]: success case",
+        ),
+    ],
+)
+def test_concat_expression(mocker, expressions, transposed_expression_lists_result, expected):
+    # elts 생성
+    elts = [mocker.MagicMock(spec=ExprObj, expressions=expr) for expr in expressions]
+    mocker.patch(
+        "app.visualize.utils.utils.transpose_with_last_fill",
+        return_value=transposed_expression_lists_result,
+    )
+
+    result = ListExpr._concat_expression(elts)
 
     assert result == expected

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_list_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_list_expr.py
@@ -1,44 +1,40 @@
 import pytest
 
-from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ListObj, ExprObj
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ListObj, ExprObj, ConstantObj, NameObj, BinopObj
 from app.visualize.analysis.stmt.parser.expr.parser.list_expr import ListExpr
 
 
 @pytest.mark.parametrize(
-    "value, expressions",
+    "elts, expected",
     [
-        pytest.param([10, 20], ("[10,20]",), id="[10, 20]: success case"),
         pytest.param(
-            [11, 20],
-            ("[a + 1,20]", "[10 + 1,20]", "[11,20]"),
+            [ConstantObj(value=10, expressions=("10",)), ConstantObj(value=20, expressions=("20",))],
+            ListObj(value=[10, 20], expressions=("[10,20]",)),
+            id="[10, 20]: success case",
+        ),
+        pytest.param(
+            [BinopObj(value=11, expressions=("a + 1", "10 + 1", "11")), ConstantObj(value=20, expressions=("20",))],
+            ListObj(value=[11, 20], expressions=("[a + 1,20]", "[10 + 1,20]", "[11,20]")),
             id="[a + 1, 20]: success case",
         ),
         pytest.param(
-            ["Hello", "World"],
-            ("['Hello','World']",),
-            id='["Hello", "World"]: success case',
-        ),
-        pytest.param(
-            ["a", "b"],
-            ("[a,b]",),
-            id="[a, b] success case",
+            [NameObj(value="Hello", expressions=("a", "Hello")), ConstantObj(value="World", expressions=("World",))],
+            ListObj(value=["Hello", "World"], expressions=("['a','World']", "['Hello','World']")),
+            id='[a, "World"]: success case',
         ),
     ],
 )
-def test_parse(mocker, value, expressions):
+def test_parse(mocker, elts: list[ExprObj], expected: ListObj):
     # _get_value mocking
-    mocker.patch("app.visualize.analysis.stmt.parser.expr.parser.list_expr.ListExpr._get_value", return_value=value)
+    mock_get_value = mocker.patch.object(ListExpr, "_get_value", return_value=expected.value)
     # _concat_expression mocking
-    mocker.patch(
-        "app.visualize.analysis.stmt.parser.expr.parser.list_expr.ListExpr._concat_expression",
-        return_value=expressions,
-    )
+    mock_concat_expressions = mocker.patch.object(ListExpr, "_concat_expressions", return_value=expected.expressions)
 
-    result = ListExpr.parse([mocker.MagicMock(spec=ExprObj) for _ in range(len(value))])
+    result = ListExpr.parse(elts)
 
     assert isinstance(result, ListObj)
-    assert result.value == value
-    assert result.expressions == expressions
+    assert mock_get_value.call_once_with(elts)
+    assert mock_concat_expressions.call_once_with(elts)
 
 
 @pytest.mark.parametrize(
@@ -85,6 +81,6 @@ def test_concat_expression(mocker, expressions, transposed_expression_lists_resu
         return_value=transposed_expression_lists_result,
     )
 
-    result = ListExpr._concat_expression(elts)
+    result = ListExpr._concat_expressions(elts)
 
     assert result == expected

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_name_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_name_expr.py
@@ -7,34 +7,43 @@ from app.visualize.analysis.stmt.parser.expr.parser.name_expr import NameExpr
 
 
 @pytest.mark.parametrize(
-    "ctx, identifier_name, value, expressions",
+    "node, expected",
     [
-        pytest.param(ast.Store(), "a", "a", ("a",), id="a ast.Store(): success case"),
-        pytest.param(ast.Store(), "abc", "abc", ("abc",), id="abc ast.Store(): success case"),
-        pytest.param(ast.Load(), "a", 10, ("a", "10"), id="a ast.Load(): success case"),
-        pytest.param(ast.Load(), "abc", 10, ("abc", "10"), id="abc ast.Load(): success case"),
+        pytest.param(
+            ast.Name(ctx=ast.Store(), id="a"), NameObj(value="a", expressions=("a",)), id="a ast.Store(): success case"
+        ),
+        pytest.param(
+            ast.Name(ctx=ast.Store(), id="abc"),
+            NameObj(value="a", expressions=("a",)),
+            id="abc ast.Store(): success case",
+        ),
+        pytest.param(
+            ast.Name(ctx=ast.Load(), id="a"),
+            NameObj(value=10, expressions=("a", "10")),
+            id="a ast.Load(): success case",
+        ),
+        pytest.param(
+            ast.Name(ctx=ast.Load(), id="a"),
+            NameObj(value=10, expressions=("a", "10")),
+            id="abc ast.Load(): success case",
+        ),
     ],
 )
-def test_parse(elem_container, mocker, ctx, identifier_name, value, expressions):
-    mocker.patch(
-        "app.visualize.analysis.stmt.parser.expr.parser.name_expr.NameExpr._get_identifier_value", return_value=value
-    )
-    mocker.patch(
-        "app.visualize.analysis.stmt.parser.expr.parser.name_expr.NameExpr._create_expressions",
-        return_value=expressions,
-    )
-    result = NameExpr.parse(ctx, identifier_name, elem_container)
+def test_parse(elem_container, mocker, node: ast.Name, expected: NameObj):
+    mock_get_identifier_value = mocker.patch.object(NameExpr, "_get_identifier_value", return_value=expected.value)
+    mock_create_expressions = mocker.patch.object(NameExpr, "_create_expressions", return_value=expected.expressions)
+    result = NameExpr.parse(node, elem_container)
 
     assert isinstance(result, NameObj)
-    assert result.value == value
-    assert result.expressions == expressions
+    assert mock_get_identifier_value.call_once_with(node.id, elem_container)
+    assert mock_create_expressions.call_once_with(node.id, expected.value)
 
 
 def test_parse_fail_ast_del(elem_container, mocker):
-    ast_del = mocker.MagicMock(spec=ast.Del)
+    ast_name_ctx_del = mocker.MagicMock(spec=ast.Name, ctx=ast.Del())
 
     with pytest.raises(NotImplementedError):
-        NameExpr.parse(ast_del, "a", elem_container)
+        NameExpr.parse(ast_name_ctx_del, elem_container)
 
 
 @pytest.mark.parametrize(

--- a/tests/visualize/utils/test_utils.py
+++ b/tests/visualize/utils/test_utils.py
@@ -1,0 +1,29 @@
+import pytest
+
+from app.visualize.utils import utils
+
+
+@pytest.mark.parametrize(
+    "expressions, expected",
+    [
+        pytest.param(
+            [("10",), ("a + 13", "5 + 13", "28"), ("b", "4")],
+            [("10", "a + 13", "b"), ("10", "5 + 13", "4"), ("10", "28", "4")],
+            id="[['10'], ['a + 13', '5 + 13', '28'], ['b', '4']] success case",
+        ),
+        pytest.param(
+            [("a", "10"), ("b", "20"), ("30",)],
+            [("a", "b", "30"), ("10", "20", "30")],
+            id="[['a', '10'], ['b', '20'], ['30']] success case",
+        ),
+        pytest.param(
+            [("10",), ("20",)],
+            [("10", "20")],
+            id="[('10',), ('20',)] success case",
+        ),
+    ],
+)
+def test_transpose_with_last_fill(expressions, expected):
+    result = utils.transpose_with_last_fill(expressions)
+
+    assert result == expected


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- ex) close #149 

## 📝 작업 내용

- pytest-mock 의존성 추가
- transpose_with_last_fill() 테스트 코드 작성
- ConstantExpr.parse() 테스트 코드 작성
- NameExpr.parse() 테스트 코드 작성
- BinopExpr.parse() 테스트 코드 작성
- ListExpr.parse() 테스트 코드 작성
- CallExpr.parse() 테스트 코드 작성

### 스크린샷 (선택)
![스크린샷 2024-07-10 오전 11 04 12](https://github.com/Co-due/Code-Analysis-Server/assets/105411445/74a142f6-8f26-4106-90a3-db7c02637070)

## 💬 리뷰 요구사항(선택)

- 기존 unittest.mock을 사용하던 방식에서 pytest-mock을 사용하는 방식으로 변경했습니다.
- 테스트 케이스에 문제가 보인다면 리뷰 부탁드려요~
- CallExpr에서 print_parse가 (end_keyword, expressions)를 내보내던 방식에서 (value, expressions)를 내보내는 방식으로 바뀌었습니다.
