### PR TITLE
[#143]feat: if-else문 시각화 애니메이션에 필요한 속성 추출 

### DIFF
--- a/app/visualize/generator/converter/if_converter.py
+++ b/app/visualize/generator/converter/if_converter.py
@@ -48,9 +48,6 @@ class IfConverter:
         return steps
 
     @staticmethod
-    def _create_condition_viz(condition: ConditionObj) -> ConditionViz:
-        expr = condition.expressions[0] if condition.type != "else" else ""
-        return ConditionViz(id=condition.id, expr=expr, type=condition.type)
     def _create_condition_evaluation_steps(condition, viz_manager):
         # 중간 과정 생성 - 10 + 20 > 30, 30 > 30
         highlights = ExprHighlight.get_highlight_indexes(condition.expressions)

--- a/app/visualize/generator/converter/if_converter.py
+++ b/app/visualize/generator/converter/if_converter.py
@@ -4,6 +4,7 @@ from app.visualize.analysis.stmt.models.if_stmt_obj import (
     ElifConditionObj,
     ElseConditionObj,
 )
+from app.visualize.generator.highlight.expr_highlight import ExprHighlight
 from app.visualize.generator.models.if_viz import ConditionViz, IfElseDefineViz, IfElseChangeViz
 from app.visualize.generator.visualization_manager import VisualizationManager
 
@@ -11,14 +12,14 @@ from app.visualize.generator.visualization_manager import VisualizationManager
 class IfConverter:
 
     @staticmethod
-    def get_header_define_viz(
+    def convert_to_if_else_define_viz(
         conditions: tuple[ConditionObj, ...], viz_manager: VisualizationManager
     ) -> IfElseDefineViz:
         if_header_conditions = []
 
         for condition in conditions:
             if isinstance(condition, ConditionObj):
-                if_header_conditions.append(IfConverter._create_condition_viz(condition))
+                if_header_conditions.append(IfConverter._create__if_else_define_viz(condition))
 
             else:
                 raise TypeError(f"[IfConverter]: 지원하지 않는 조건문 타입입니다.: {type(condition)}")
@@ -26,7 +27,12 @@ class IfConverter:
         return IfElseDefineViz(depth=viz_manager.get_depth(), conditions=tuple(if_header_conditions))
 
     @staticmethod
-    def get_header_change_steps(
+    def _create__if_else_define_viz(condition: ConditionObj) -> ConditionViz:
+        expr = condition.expressions[0] if condition.type != "else" else ""
+        return ConditionViz(id=condition.id, expr=expr, type=condition.type)
+
+    @staticmethod
+    def convert_to_if_else_change_viz(
         conditions: tuple[ConditionObj, ...], viz_manager: VisualizationManager
     ) -> list[IfElseChangeViz]:
         steps = []
@@ -35,12 +41,11 @@ class IfConverter:
             if not isinstance(condition, ConditionObj):
                 raise TypeError(f"[IfConverter]: 지원하지 않는 조건문 타입입니다.: {type(condition)}")
 
+            # 조건식 평가 과정 추가
             if type(condition) in (IfConditionObj, ElifConditionObj):
-                for expression in condition.expressions:
-                    steps.append(IfElseChangeViz(id=condition.id, depth=viz_manager.get_depth(), expr=expression))
-
-            # 결과 처리 : condition의 결과 추가
-            steps.append(IfElseChangeViz(id=condition.id, depth=viz_manager.get_depth(), expr=str(condition.result)))
+                steps.extend(IfConverter._create_condition_evaluation_steps(condition, viz_manager))
+            # 조건식 평가 결과 추가
+            steps.extend(IfConverter._create_condition_result(condition, viz_manager))
 
             if steps[-1].expr == "True":
                 return steps

--- a/app/visualize/generator/converter/if_converter.py
+++ b/app/visualize/generator/converter/if_converter.py
@@ -51,3 +51,28 @@ class IfConverter:
     def _create_condition_viz(condition: ConditionObj) -> ConditionViz:
         expr = condition.expressions[0] if condition.type != "else" else ""
         return ConditionViz(id=condition.id, expr=expr, type=condition.type)
+    def _create_condition_evaluation_steps(condition, viz_manager):
+        # 중간 과정 생성 - 10 + 20 > 30, 30 > 30
+        highlights = ExprHighlight.get_highlight_indexes(condition.expressions)
+
+        return [
+            IfElseChangeViz(
+                id=condition.id,
+                depth=viz_manager.get_depth(),
+                expr=expression,
+                highlights=highlights[idx],
+            )
+            for idx, expression in enumerate(condition.expressions)
+        ]
+
+    @staticmethod
+    def _create_condition_result(condition, viz_manager):
+        # 결과 처리 : condition의 결과 추가
+        return [
+            IfElseChangeViz(
+                id=condition.id,
+                depth=viz_manager.get_depth(),
+                expr=str(condition.result),
+                highlights=list(range(len(str(condition.result)))),
+            )
+        ]

--- a/app/visualize/generator/converter/if_converter.py
+++ b/app/visualize/generator/converter/if_converter.py
@@ -52,9 +52,14 @@ class IfConverter:
         return steps
 
     @staticmethod
-    def _create_condition_evaluation_steps(condition, viz_manager):
+    def _create_condition_evaluation_steps(
+        condition: ConditionObj, viz_manager: VisualizationManager
+    ) -> list[IfElseChangeViz]:
         # 중간 과정 생성 - 10 + 20 > 30, 30 > 30
         highlights = ExprHighlight.get_highlight_indexes(condition.expressions)
+
+        if condition.expressions[0] == "True" or condition.expressions[0] == "False":
+            return []
 
         return [
             IfElseChangeViz(
@@ -67,7 +72,7 @@ class IfConverter:
         ]
 
     @staticmethod
-    def _create_condition_result(condition, viz_manager):
+    def _create_condition_result(condition: ConditionObj, viz_manager: VisualizationManager) -> list[IfElseChangeViz]:
         # 결과 처리 : condition의 결과 추가
         return [
             IfElseChangeViz(

--- a/app/visualize/generator/converter/if_converter.py
+++ b/app/visualize/generator/converter/if_converter.py
@@ -18,11 +18,10 @@ class IfConverter:
         if_header_conditions = []
 
         for condition in conditions:
-            if isinstance(condition, ConditionObj):
-                if_header_conditions.append(IfConverter._create__if_else_define_viz(condition))
-
-            else:
+            if not isinstance(condition, ConditionObj):
                 raise TypeError(f"[IfConverter]: 지원하지 않는 조건문 타입입니다.: {type(condition)}")
+
+            if_header_conditions.append(IfConverter._create__if_else_define_viz(condition))
 
         return IfElseDefineViz(depth=viz_manager.get_depth(), conditions=tuple(if_header_conditions))
 

--- a/app/visualize/generator/converter_traveler.py
+++ b/app/visualize/generator/converter_traveler.py
@@ -59,9 +59,9 @@ class ConverterTraveler:
     def _if_convert(if_stmt: IfStmtObj, viz_manager: VisualizationManager):
         steps = list()
         # 1. if-else 구조 define
-        steps.append(IfConverter.get_header_define_viz(if_stmt.conditions, viz_manager))
+        steps.append(IfConverter.convert_to_if_else_define_viz(if_stmt.conditions, viz_manager))
         # 2. if header
-        steps.extend(IfConverter.get_header_change_steps(if_stmt.conditions, viz_manager))
+        steps.extend(IfConverter.convert_to_if_else_change_viz(if_stmt.conditions, viz_manager))
         # 3. if header 결과 값이 true인 if 문의 body obj의 viz 생성
         if not if_stmt.body:
             raise ValueError("[ConverterTraveler] if_stmt.body is None")

--- a/app/visualize/generator/models/if_viz.py
+++ b/app/visualize/generator/models/if_viz.py
@@ -20,4 +20,5 @@ class IfElseChangeViz:
     id: int
     depth: int
     expr: str
+    highlights: []
     type: str = "ifElseChange"

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_binop_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_binop_expr.py
@@ -1,5 +1,4 @@
 import ast
-from unittest import mock
 
 import pytest
 

--- a/tests/visualize/generator/converter/test_if_converter.py
+++ b/tests/visualize/generator/converter/test_if_converter.py
@@ -168,7 +168,7 @@ def test_convert_to_if_else_change_viz(
 
 
 @pytest.mark.parametrize(
-    "condition,highlights, expected",
+    "condition, highlights, expected",
     [
         pytest.param(
             IfConditionObj(id=1, expressions=("a > b", "10 > 20"), result=False),
@@ -182,9 +182,7 @@ def test_convert_to_if_else_change_viz(
         pytest.param(
             IfConditionObj(id=1, expressions=("True",), result=False),
             [[0, 1, 2, 3]],
-            [
-                IfElseChangeViz(id=1, depth=1, expr="True", highlights=[0, 1, 2, 3]),
-            ],
+            [],
             id="True 조건식 평가 과정 success",
         ),
     ],

--- a/tests/visualize/generator/converter/test_if_converter.py
+++ b/tests/visualize/generator/converter/test_if_converter.py
@@ -47,7 +47,7 @@ from app.visualize.generator.visualization_manager import VisualizationManager
     ],
 )
 def test_get_header_define_viz(conditions: tuple[ConditionObj, ...], expected):
-    actual = IfConverter.get_header_define_viz(conditions, VisualizationManager())
+    actual = IfConverter.convert_to_if_else_define_viz(conditions, VisualizationManager())
     assert actual.conditions == expected
 
 
@@ -73,7 +73,7 @@ def test_get_header_define_viz(conditions: tuple[ConditionObj, ...], expected):
     ],
 )
 def test_get_header_change_steps(conditions: tuple[ConditionObj, ...], expected, mock_viz_manager_with_custom_depth):
-    actual = IfConverter.get_header_change_steps(conditions, mock_viz_manager_with_custom_depth(1))
+    actual = IfConverter.convert_to_if_else_change_viz(conditions, mock_viz_manager_with_custom_depth(1))
     assert actual == expected
 
 
@@ -119,4 +119,4 @@ def test_get_header_change_steps(conditions: tuple[ConditionObj, ...], expected,
     ],
 )
 def test__create_condition_viz(condition: ConditionObj, condition_type, expected):
-    assert IfConverter._create_condition_viz(condition) == expected
+    assert IfConverter._create__if_else_define_viz(condition) == expected

--- a/tests/visualize/generator/converter/test_if_converter.py
+++ b/tests/visualize/generator/converter/test_if_converter.py
@@ -120,7 +120,8 @@ def test_convert_to_if_else_define_viz_fail(conditions: tuple[ConditionObj, ...]
     ],
 )
 def test__create_condition_viz(condition: ConditionObj, condition_type, expected):
-    assert IfConverter._create__if_else_define_viz(condition) == expected
+    actual = IfConverter._create__if_else_define_viz(condition)
+    assert actual == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/visualize/generator/converter/test_if_converter.py
+++ b/tests/visualize/generator/converter/test_if_converter.py
@@ -1,12 +1,19 @@
+from unittest.mock import patch
+
 import pytest
 
+from app.visualize.analysis.stmt.models.assign_stmt_obj import AssignStmtObj
+from app.visualize.analysis.stmt.models.for_stmt_obj import BodyObj
 from app.visualize.analysis.stmt.models.if_stmt_obj import (
     IfConditionObj,
     ElifConditionObj,
     ElseConditionObj,
     ConditionObj,
+    IfStmtObj,
 )
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import PrintObj
 from app.visualize.generator.converter.if_converter import IfConverter
+from app.visualize.generator.highlight.expr_highlight import ExprHighlight
 from app.visualize.generator.models.if_viz import ConditionViz, IfElseChangeViz
 from app.visualize.generator.visualization_manager import VisualizationManager
 
@@ -46,35 +53,29 @@ from app.visualize.generator.visualization_manager import VisualizationManager
         )
     ],
 )
-def test_get_header_define_viz(conditions: tuple[ConditionObj, ...], expected):
+def test_convert_to_if_else_define_viz(conditions: tuple[ConditionObj, ...], expected):
     actual = IfConverter.convert_to_if_else_define_viz(conditions, VisualizationManager())
     assert actual.conditions == expected
 
 
 @pytest.mark.parametrize(
-    "conditions,expected",
+    "conditions",
     [
-        pytest.param(
-            (IfConditionObj(id=1, expressions=("a > b", "10 > 20"), result=False),),
-            [
-                IfElseChangeViz(id=1, depth=1, expr="a > b"),
-                IfElseChangeViz(id=1, depth=1, expr="10 > 20"),
-                IfElseChangeViz(id=1, depth=1, expr="False"),
-            ],
-            id="if문 False인 경우",
-        ),
-        pytest.param(
-            (ElseConditionObj(id=1, expressions=None, result=True),),
-            [
-                IfElseChangeViz(id=1, depth=1, expr="True"),
-            ],
-            id="else문 True인 경우",
+        ((PrintObj(value="abc ", expressions=("abc",))),),
+        (
+            (
+                IfStmtObj(
+                    conditions=(IfConditionObj(id=1, expressions=("a > b", "10 > 20"), result=False),),
+                    body=BodyObj(cur_value=0, body_steps=(AssignStmtObj(targets="a", expr_stmt_obj="10"),)),
+                    type="if",
+                )
+            )
         ),
     ],
 )
-def test_get_header_change_steps(conditions: tuple[ConditionObj, ...], expected, mock_viz_manager_with_custom_depth):
-    actual = IfConverter.convert_to_if_else_change_viz(conditions, mock_viz_manager_with_custom_depth(1))
-    assert actual == expected
+def test_convert_to_if_else_define_viz_fail(conditions: tuple[ConditionObj, ...]):
+    with pytest.raises(TypeError):
+        IfConverter.convert_to_if_else_define_viz(conditions, VisualizationManager())
 
 
 @pytest.mark.parametrize(
@@ -120,3 +121,99 @@ def test_get_header_change_steps(conditions: tuple[ConditionObj, ...], expected,
 )
 def test__create_condition_viz(condition: ConditionObj, condition_type, expected):
     assert IfConverter._create__if_else_define_viz(condition) == expected
+
+
+@pytest.mark.parametrize(
+    "conditions,expected",
+    [
+        pytest.param(
+            (IfConditionObj(id=1, expressions=("a > b", "10 > 20"), result=False),),
+            [
+                IfElseChangeViz(id=1, depth=1, expr="a > b", highlights=[0, 1, 2, 3, 4]),
+                IfElseChangeViz(id=1, depth=1, expr="10 > 20", highlights=[0, 1, 2, 3, 4, 5, 6]),
+                IfElseChangeViz(id=1, depth=1, expr="False", highlights=[0, 1, 2, 3, 4]),
+            ],
+            id="if문 False인 경우",
+        ),
+        pytest.param(
+            (IfConditionObj(id=1, expressions=("a < b", "10 < 20"), result=True),),
+            [
+                IfElseChangeViz(id=1, depth=1, expr="a < b", highlights=[0, 1, 2, 3, 4]),
+                IfElseChangeViz(id=1, depth=1, expr="10 < 20", highlights=[0, 1, 2, 3, 4, 5, 6]),
+                IfElseChangeViz(id=1, depth=1, expr="True", highlights=[0, 1, 2, 3, 4]),
+            ],
+            id="elif문 True 경우",
+        ),
+    ],
+)
+def test_convert_to_if_else_change_viz(
+    conditions: tuple[ConditionObj, ...], expected, mock_viz_manager_with_custom_depth
+):
+    with (
+        patch.object(
+            IfConverter,
+            "_create_condition_evaluation_steps",
+        ) as mock_create_condition_evaluation_steps,
+        patch.object(
+            IfConverter,
+            "_create_condition_result",
+            return_value=[IfElseChangeViz(id=1, depth=1, expr="True", highlights=[0])],
+        ) as mock_create_condition_result,
+    ):
+        mock_viz_manager = mock_viz_manager_with_custom_depth(1)
+        actual = IfConverter.convert_to_if_else_change_viz(conditions, mock_viz_manager)
+
+        mock_create_condition_evaluation_steps.assert_called_with(conditions[0], mock_viz_manager)
+        mock_create_condition_result.assert_called_with(conditions[0], mock_viz_manager)
+
+
+@pytest.mark.parametrize(
+    "condition,highlights, expected",
+    [
+        pytest.param(
+            IfConditionObj(id=1, expressions=("a > b", "10 > 20"), result=False),
+            [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4, 5, 6]],
+            [
+                IfElseChangeViz(id=1, depth=1, expr="a > b", highlights=[0, 1, 2, 3, 4]),
+                IfElseChangeViz(id=1, depth=1, expr="10 > 20", highlights=[0, 1, 2, 3, 4, 5, 6]),
+            ],
+            id="a > 10 조건식 평가 과정 success",
+        ),
+        pytest.param(
+            IfConditionObj(id=1, expressions=("True",), result=False),
+            [[0, 1, 2, 3]],
+            [
+                IfElseChangeViz(id=1, depth=1, expr="True", highlights=[0, 1, 2, 3]),
+            ],
+            id="True 조건식 평가 과정 success",
+        ),
+    ],
+)
+def test__create_condition_evaluation_steps(condition, highlights, expected, mock_viz_manager_with_custom_depth):
+    with patch.object(ExprHighlight, "get_highlight_indexes", side_effect=[highlights]):
+        actual = IfConverter._create_condition_evaluation_steps(condition, mock_viz_manager_with_custom_depth(1))
+        assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "condition,expected",
+    [
+        pytest.param(
+            IfConditionObj(id=1, expressions=("a > b", "10 > 20"), result=True),
+            [
+                IfElseChangeViz(id=1, depth=1, expr="True", highlights=[0, 1, 2, 3]),
+            ],
+            id="최종 결과가 True 인 경우",
+        ),
+        pytest.param(
+            IfConditionObj(id=1, expressions=("a < b", "20 < 10"), result=False),
+            [
+                IfElseChangeViz(id=1, depth=1, expr="False", highlights=[0, 1, 2, 3, 4]),
+            ],
+            id="최종 결과가 False 인 경우",
+        ),
+    ],
+)
+def test__create_condition_result(condition, expected, mock_viz_manager_with_custom_depth):
+    actual = IfConverter._create_condition_result(condition, mock_viz_manager_with_custom_depth(1))
+    assert actual == expected

--- a/tests/visualize/generator/test_converter_traveler.py
+++ b/tests/visualize/generator/test_converter_traveler.py
@@ -21,16 +21,16 @@ def get_if_stmt_obj():
 def test__if_convert(get_if_stmt_obj, mock_viz_manager_with_custom_depth):
     if_stmt_obj = get_if_stmt_obj("if 9 == 10:\n    print('hello')\nelif 9 < 10:\n    print('world')\n")
     with (
-        patch.object(IfConverter, "get_header_define_viz") as mock_get_header_define_viz,
-        patch.object(IfConverter, "get_header_change_steps") as mock_get_header_change_steps,
+        patch.object(IfConverter, "convert_to_if_else_define_viz") as mock_convert_to_if_else_define_viz,
+        patch.object(IfConverter, "convert_to_if_else_change_viz") as mock_convert_to_if_else_change_viz,
         patch.object(ConverterTraveler, "_get_if_body_viz_list") as mock_get_if_body_viz_list,
     ):
         mock_viz_manager = mock_viz_manager_with_custom_depth(1)
         ConverterTraveler._if_convert(if_stmt_obj, mock_viz_manager)
 
         # 함수들이 호출 되었는지 확인
-        mock_get_header_define_viz.assert_called_once_with(if_stmt_obj.conditions, mock_viz_manager)
-        mock_get_header_change_steps.assert_called_once_with(if_stmt_obj.conditions, mock_viz_manager)
+        mock_convert_to_if_else_define_viz.assert_called_once_with(if_stmt_obj.conditions, mock_viz_manager)
+        mock_convert_to_if_else_change_viz.assert_called_once_with(if_stmt_obj.conditions, mock_viz_manager)
         mock_get_if_body_viz_list.assert_called_once_with(if_stmt_obj.body, mock_viz_manager)
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #143

## 📝 작업 내용

- if문 시각화에 필요한 하이라이트 추출 - if 문 조건절에 대한 하이라이트를 추가했습니다.
- if_coverter 내부의 함수를 리팩토링 했습니다. 하이라이트 추가하다보니 한 함수에서 다 하는 것 같아서 쪼갰습니다.
- 바뀐 구조와 하이라이트 로직 추가한 것에 대한 테스트 코드를 작성했습니다.

### 스크린샷 (선택)
코드
```python
if (a + 10 > 10):
    print("환영합니다.")
```
```python
IfElseDefineViz(depth=1, conditions=(ConditionViz(id=3, expr='a + 10 > 10', type='if'), ConditionViz(id=5, expr='a > 10', type='elif')), type='ifElseDefine'),
IfElseChangeViz(id=3, depth=1, expr='a + 10 > 10', highlights=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], type='ifElseChange'),
IfElseChangeViz(id=3, depth=1, expr='10 + 10 > 10', highlights=[0, 1], type='ifElseChange'),
IfElseChangeViz(id=3, depth=1, expr='20 > 10', highlights=[0, 1, 2, 3, 4, 5, 6], type='ifElseChange'),
IfElseChangeViz(id=3, depth=1, expr='True', highlights=[0, 1, 2, 3], type='ifElseChange'),
PrintViz(id=4, depth=2, expr="'환영합니다.'", highlights=[0, 1, 2, 3, 4, 5, 6, 7], console="'환영합니다.'\n", type='print'),
```
## 💬 리뷰 요구사항(선택)

- 이상하게 pytest의 목업으로 수정한 테스트들이 실패가 뜨네요. 설정문제 같은데 우선 참고하세요~
![image](https://github.com/user-attachments/assets/60fe008e-0c44-49dc-a10b-bee681596cbf)

