### PR TITLE
[#160]refactor: unitest의 mock에서 pytest의 목업을 사용

### DIFF
--- a/tests/visualize/analysis/stmt/parser/test_for_stmt.py
+++ b/tests/visualize/analysis/stmt/parser/test_for_stmt.py
@@ -28,4 +28,3 @@ def test__get_target_name_fail(elem_container, target):
     # 예외가 터지면 통과, 안터지면 실
     with pytest.raises(TypeError, match=r"\[ForParser\]:  .*는 잘못된 타입입니다."):
         ForStmt._get_target_name(target, elem_container)
-        assert False

--- a/tests/visualize/analysis/stmt/parser/test_for_stmt.py
+++ b/tests/visualize/analysis/stmt/parser/test_for_stmt.py
@@ -1,10 +1,7 @@
 import ast
-from unittest.mock import patch
 import pytest
 
-from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj
 from app.visualize.analysis.stmt.parser.for_stmt import ForStmt
-from app.visualize.analysis.stmt.parser.expr_stmt import ExprTraveler
 
 
 @pytest.mark.parametrize(
@@ -17,7 +14,6 @@ from app.visualize.analysis.stmt.parser.expr_stmt import ExprTraveler
 def test__get_target_name(elem_container, target, expect):
     # target 노드를 받아서 변수 이름을 반환하는지 테스트
     result = ForStmt._get_target_name(target, elem_container)
-
     assert result == expect
 
 
@@ -32,38 +28,4 @@ def test__get_target_name_fail(elem_container, target):
     # 예외가 터지면 통과, 안터지면 실
     with pytest.raises(TypeError, match=r"\[ForParser\]:  .*는 잘못된 타입입니다."):
         ForStmt._get_target_name(target, elem_container)
-
-
-# TODO 함수마다 parser를 추가하는 방향 고민
-@pytest.mark.parametrize(
-    "code, expect",
-    [
-        (
-            """for i in range(3): \n    pass""",
-            ExprObj(
-                type="range",
-                value={"end": "3", "start": "0", "step": "1"},
-                expressions=[{"end": "3", "start": "0", "step": "1"}],
-            ),
-        )
-    ],
-)
-@pytest.mark.skip
-def test_get_condition_obj(create_ast, elem_container, code, expect):
-    # iter 노드를 받아서 range 함수의 파라미터를 반환하는지 테스트
-    iter_node = create_ast(code).iter
-
-    with patch.object(
-        ExprTraveler,
-        "call_travel",
-        return_value=ExprObj(
-            type="range",
-            value={"end": "3", "start": "0", "step": "1"},
-            expressions=[{"end": "3", "start": "0", "step": "1"}],
-        ),
-    ):
-        actual = ForStmt._get_condition_obj(iter_node, elem_container)
-        assert actual == expect
-
-
-# 141]test: IfStmt 함수들 유닛 테스트)
+        assert False

--- a/tests/visualize/analysis/stmt/parser/test_if_stmt.py
+++ b/tests/visualize/analysis/stmt/parser/test_if_stmt.py
@@ -1,5 +1,4 @@
-import ast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -30,14 +29,15 @@ from app.visualize.container.element_container import ElementContainer
     ],
 )
 def test_parse_if_condition(
-    input_code, expected, travel_return_value, evaluate_test_value_return, create_ast, elem_manager
+    mocker, input_code, expected, travel_return_value, evaluate_test_value_return, create_ast, elem_manager
 ):
     test_node = create_ast(input_code).value
-    with (
-        patch.object(ExprTraveler, "travel", return_value=travel_return_value),
-        patch.object(IfStmt, "_evaluate_test_value", return_value=evaluate_test_value_return),
-    ):
-        assert IfStmt.parse_if_condition(test_node, elem_manager) == expected
+    mocker.patch.object(ExprTraveler, "travel", return_value=travel_return_value),
+    mocker.patch.object(IfStmt, "_evaluate_test_value", return_value=evaluate_test_value_return),
+
+    actual = IfStmt.parse_if_condition(test_node, elem_manager)
+
+    assert actual == expected
 
 
 @pytest.mark.parametrize(
@@ -60,14 +60,15 @@ def test_parse_if_condition(
     ],
 )
 def test_parse_elif_condition(
-    input_code, expected, travel_return_value, evaluate_test_return_value, create_ast, elem_container
+    mocker, input_code, expected, travel_return_value, evaluate_test_return_value, create_ast, elem_container
 ):
     test_node = create_ast(input_code).value
-    with (
-        patch.object(ExprTraveler, "travel", return_value=travel_return_value),
-        patch.object(IfStmt, "_evaluate_test_value", return_value=evaluate_test_return_value),
-    ):
-        assert IfStmt.parse_elif_condition(test_node, elem_container) == expected
+    mocker.patch.object(ExprTraveler, "travel", return_value=travel_return_value)
+    mocker.patch.object(IfStmt, "_evaluate_test_value", return_value=evaluate_test_return_value)
+
+    actual = IfStmt.parse_elif_condition(test_node, elem_container)
+
+    assert actual == expected
 
 
 @pytest.mark.parametrize(
@@ -88,7 +89,9 @@ def test_parse_elif_condition(
 def test_parse_if_condition(input_code, expected, create_ast):
     else_body_node = create_ast(input_code).value
 
-    assert IfStmt.parse_else_condition(else_body_node, True) == expected
+    actual = IfStmt.parse_else_condition(else_body_node, True)
+
+    assert actual == expected
 
 
 @pytest.mark.parametrize(
@@ -121,4 +124,6 @@ def test__evaluate_test_value(input_code: str, expected, create_ast):
     elem_manager = MagicMock(spec=ElementContainer)
     elem_manager.get_element_dict.return_value = {"a": 10, "b": 12}
 
-    assert IfStmt._evaluate_test_value(test_node, elem_manager) == expected
+    actual = IfStmt._evaluate_test_value(test_node, elem_manager)
+
+    assert actual == expected

--- a/tests/visualize/analysis/test_stmt_traveler.py
+++ b/tests/visualize/analysis/test_stmt_traveler.py
@@ -76,33 +76,28 @@ def test_if_travel(mocker, code: str, expect, elem_container):
 
 
 @pytest.mark.parametrize(
-    "conditions, node, expected",
+    "conditions, node, called_func",
     [
         pytest.param(
             [],
             ast.If(test=ast.parse("a>10").body[0].value),
-            IfConditionObj(id=1, expressions=("a>10",), result=False),
+            "parse_if_condition",
             id="conditions is empty",
         ),
         pytest.param(
             [IfConditionObj(id=1, expressions=("a>10",), result=False)],
             ast.If(test=ast.parse("True").body[0].value),
-            ElifConditionObj(id=2, expressions=("a<10",), result=False),
+            "parse_elif_condition",
             id="conditions is not empty",
         ),
     ],
 )
-def test_append_condition_obj(mocker, conditions, node: ast.stmt, expected, elem_container, create_ast):
-    mocker.patch.object(
-        IfStmt, "parse_if_condition", return_value=IfConditionObj(id=1, expressions=("a>10",), result=False)
-    ),
-    mocker.patch.object(
-        IfStmt, "parse_elif_condition", return_value=ElifConditionObj(id=2, expressions=("a<10",), result=False)
-    )
+def test_append_condition_obj(mocker, conditions, node: ast.If, called_func, elem_container, create_ast):
+    mock_func = mocker.patch.object(IfStmt, called_func)
 
     StmtTraveler._append_condition_obj(conditions, elem_container, node)
 
-    assert conditions[-1] == expected
+    mock_func.assert_called_once_with(node.test, elem_container)
 
 
 @pytest.mark.parametrize(

--- a/tests/visualize/analysis/test_stmt_traveler.py
+++ b/tests/visualize/analysis/test_stmt_traveler.py
@@ -1,5 +1,6 @@
 import ast
-from unittest.mock import patch, MagicMock
+
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -56,19 +57,22 @@ else:
         ),
     ],
 )
-def test_if_travel(code: str, expect, elem_container):
+def test_if_travel(mocker, code: str, expect, elem_container):
     ast_if = ast.parse(code).body[0]
-    with patch.object(
+    mocker.patch.object(
         IfStmt, "parse_if_condition", return_value=IfConditionObj(id=1, expressions=("a>10",), result=False)
-    ), patch.object(
+    )
+    mocker.patch.object(
         IfStmt, "parse_elif_condition", return_value=ElifConditionObj(id=2, expressions=("a<10",), result=False)
-    ), patch.object(
+    )
+    mocker.patch.object(
         IfStmt, "parse_else_condition", return_value=ElseConditionObj(id=3, expressions=None, result=True)
-    ), patch.object(
-        StmtTraveler, "travel", return_value=[]
-    ):
-        actual = StmtTraveler._if_travel(ast_if, [], [], elem_container)
-        assert actual == expect
+    )
+    mocker.patch.object(StmtTraveler, "travel", return_value=[])
+
+    actual = StmtTraveler._if_travel(ast_if, [], [], elem_container)
+
+    assert actual == expect
 
 
 @pytest.mark.parametrize(
@@ -88,14 +92,17 @@ def test_if_travel(code: str, expect, elem_container):
         ),
     ],
 )
-def test_append_condition_obj(conditions, node: ast.stmt, expected, elem_container, create_ast):
-    with patch.object(
+def test_append_condition_obj(mocker, conditions, node: ast.stmt, expected, elem_container, create_ast):
+    mocker.patch.object(
         IfStmt, "parse_if_condition", return_value=IfConditionObj(id=1, expressions=("a>10",), result=False)
-    ), patch.object(
+    ),
+    mocker.patch.object(
         IfStmt, "parse_elif_condition", return_value=ElifConditionObj(id=2, expressions=("a<10",), result=False)
-    ):
-        StmtTraveler._append_condition_obj(conditions, elem_container, node)
-        assert conditions[-1] == expected
+    )
+
+    StmtTraveler._append_condition_obj(conditions, elem_container, node)
+
+    assert conditions[-1] == expected
 
 
 @pytest.mark.parametrize(
@@ -117,17 +124,18 @@ def test_append_condition_obj(conditions, node: ast.stmt, expected, elem_contain
         ),
     ],
 )
-def test_append_else_condition_obj(conditions, node: ast.stmt, result: bool, expected):
-    with patch.object(
+def test_append_else_condition_obj(mocker, conditions, node: ast.stmt, result: bool, expected):
+    mocker.patch.object(
         IfStmt,
         "parse_else_condition",
         side_effect=[
             ElseConditionObj(id=0, expressions=None, result=True),
             ElseConditionObj(id=0, expressions=None, result=False),
         ],
-    ):
-        StmtTraveler._append_else_condition_obj(conditions, node, result)
-        assert conditions[-1].id == expected.id
+    )
+    StmtTraveler._append_else_condition_obj(conditions, node, result)
+
+    assert conditions[-1].id == expected.id
 
 
 @pytest.mark.parametrize(
@@ -141,14 +149,15 @@ def test_append_else_condition_obj(conditions, node: ast.stmt, result: bool, exp
         ),
     ],
 )
-def test_parse_if_body_추가(node: ast.If, conditions: list[ConditionObj], body_objs: list[BodyObj]):
-    with patch.object(
+def test_parse_if_body_추가(mocker, node: ast.If, conditions: list[ConditionObj], body_objs: list[BodyObj]):
+    mocker.patch.object(
         StmtTraveler,
         "travel",
         return_value=ExprStmtObj(id=0, value="hello", expressions=("hello",), expr_type="print"),
-    ):
-        StmtTraveler._parse_if_body(node, conditions, body_objs, MagicMock())
-        assert body_objs[-1] == ExprStmtObj(id=0, value="hello", expressions=("hello",), expr_type="print")
+    )
+    StmtTraveler._parse_if_body(node, conditions, body_objs, MagicMock())
+
+    assert body_objs[-1] == ExprStmtObj(id=0, value="hello", expressions=("hello",), expr_type="print")
 
 
 @pytest.mark.parametrize(
@@ -163,16 +172,17 @@ def test_parse_if_body_추가(node: ast.If, conditions: list[ConditionObj], body
     ],
 )
 def test_parse_if_body_추가_안함(
-    node: ast.If, conditions: list[ConditionObj], body_objs: list[BodyObj], elem_container
+    mocker, node: ast.If, conditions: list[ConditionObj], body_objs: list[BodyObj], elem_container
 ):
-    with patch.object(
+    mocker.patch.object(
         StmtTraveler,
         "travel",
         return_value=ExprStmtObj(id=0, value="hello", expressions=("hello",), expr_type="print"),
-    ):
-        temp_body_objs = list(body_objs)
-        StmtTraveler._parse_if_body(node, conditions, body_objs, MagicMock())
-        assert temp_body_objs == body_objs
+    )
+    temp_body_objs = list(body_objs)
+    StmtTraveler._parse_if_body(node, conditions, body_objs, MagicMock())
+
+    assert temp_body_objs == body_objs
 
 
 @pytest.mark.parametrize(
@@ -185,13 +195,13 @@ def test_parse_if_body_추가_안함(
         )
     ],
 )
-def test_parse_if_orelse_elif문_분기_실행(node: ast.If, conditions, elem_container):
+def test_parse_if_orelse_elif문_분기_실행(mocker, node: ast.If, conditions, elem_container):
     body_objs = []
-    with patch.object(StmtTraveler, "_if_travel", return_value=None) as mock_if_travel:
-        StmtTraveler._parse_if_branches(body_objs, conditions, elem_container, node.orelse)
+    mock_if_travel = mocker.patch.object(StmtTraveler, "_if_travel", return_value=None)
+    StmtTraveler._parse_if_branches(body_objs, conditions, elem_container, node.orelse)
 
-        mock_if_travel.assert_called_once()
-        mock_if_travel.assert_called_with(node.orelse[0], conditions, body_objs, elem_container)
+    mock_if_travel.assert_called_once()
+    mock_if_travel.assert_called_once_with(node.orelse[0], conditions, body_objs, elem_container)
 
 
 @pytest.mark.parametrize(
@@ -203,12 +213,12 @@ def test_parse_if_orelse_elif문_분기_실행(node: ast.If, conditions, elem_co
         )
     ],
 )
-def test_parse_if_orelse_else문_분기_실행(node: ast.If, elem_container):
-    with patch.object(StmtTraveler, "_parse_else", return_value=None) as mock_if_travel:
-        StmtTraveler._parse_if_branches([], [], elem_container, node.orelse)
+def test_parse_if_orelse_else문_분기_실행(mocker, node: ast.If, elem_container):
+    mock_if_travel = mocker.patch.object(StmtTraveler, "_parse_else", return_value=None)
+    StmtTraveler._parse_if_branches([], [], elem_container, node.orelse)
 
-        mock_if_travel.assert_called_once()
-        mock_if_travel.assert_called_with([], [], elem_container, node.orelse)
+    mock_if_travel.assert_called_once()
+    mock_if_travel.assert_called_with([], [], elem_container, node.orelse)
 
 
 @pytest.mark.parametrize(

--- a/tests/visualize/generator/converter/test_if_converter.py
+++ b/tests/visualize/generator/converter/test_if_converter.py
@@ -55,6 +55,7 @@ from app.visualize.generator.visualization_manager import VisualizationManager
 )
 def test_convert_to_if_else_define_viz(conditions: tuple[ConditionObj, ...], expected):
     actual = IfConverter.convert_to_if_else_define_viz(conditions, VisualizationManager())
+
     assert actual.conditions == expected
 
 
@@ -119,7 +120,7 @@ def test_convert_to_if_else_define_viz_fail(conditions: tuple[ConditionObj, ...]
         ),
     ],
 )
-def test__create_condition_viz(condition: ConditionObj, condition_type, expected):
+def test__create__if_else_define_viz(condition: ConditionObj, condition_type, expected):
     actual = IfConverter._create__if_else_define_viz(condition)
     assert actual == expected
 
@@ -215,4 +216,5 @@ def test__create_condition_evaluation_steps(condition, highlights, expected, moc
 )
 def test__create_condition_result(condition, expected, mock_viz_manager_with_custom_depth):
     actual = IfConverter._create_condition_result(condition, mock_viz_manager_with_custom_depth(1))
+
     assert actual == expected

--- a/tests/visualize/generator/test_converter_traveler.py
+++ b/tests/visualize/generator/test_converter_traveler.py
@@ -20,31 +20,30 @@ def get_if_stmt_obj():
     return _get_if_stmt_obj
 
 
-def test__if_convert(get_if_stmt_obj, mock_viz_manager_with_custom_depth):
+def test__if_convert(mocker, get_if_stmt_obj, mock_viz_manager_with_custom_depth):
     if_stmt_obj = get_if_stmt_obj("if 9 == 10:\n    print('hello')\nelif 9 < 10:\n    print('world')\n")
-    with (
-        patch.object(IfConverter, "convert_to_if_else_define_viz") as mock_convert_to_if_else_define_viz,
-        patch.object(IfConverter, "convert_to_if_else_change_viz") as mock_convert_to_if_else_change_viz,
-        patch.object(ConverterTraveler, "_get_if_body_viz_list") as mock_get_if_body_viz_list,
-    ):
-        mock_viz_manager = mock_viz_manager_with_custom_depth(1)
-        ConverterTraveler._if_convert(if_stmt_obj, mock_viz_manager)
+    mock_get_header_define_viz = mocker.patch.object(IfConverter, "convert_to_if_else_define_viz")
+    mock_get_header_change_steps = mocker.patch.object(IfConverter, "convert_to_if_else_change_viz")
+    mock_get_if_body_viz_list = mocker.patch.object(ConverterTraveler, "_get_if_body_viz_list")
+    mock_viz_manager = mock_viz_manager_with_custom_depth(1)
 
-        # 함수들이 호출 되었는지 확인
-        mock_convert_to_if_else_define_viz.assert_called_once_with(if_stmt_obj.conditions, mock_viz_manager)
-        mock_convert_to_if_else_change_viz.assert_called_once_with(if_stmt_obj.conditions, mock_viz_manager)
-        mock_get_if_body_viz_list.assert_called_once_with(if_stmt_obj.body, mock_viz_manager)
+    ConverterTraveler._if_convert(if_stmt_obj, mock_viz_manager)
+
+    # 함수들이 호출 되었는지 확인
+    mock_get_header_define_viz.assert_called_once_with(if_stmt_obj.conditions, mock_viz_manager)
+    mock_get_header_change_steps.assert_called_once_with(if_stmt_obj.conditions, mock_viz_manager)
+    mock_get_if_body_viz_list.assert_called_once_with(if_stmt_obj.body, mock_viz_manager)
 
 
-def test__get_if_body_viz_list(get_if_stmt_obj):
+def test__get_if_body_viz_list(mocker, get_if_stmt_obj):
     if_stmt_obj = get_if_stmt_obj("if 9 == 10:\n    print('hello')\nelif 9 < 10:\n    print('world')\n")
+    mock_travel = mocker.patch.object(ConverterTraveler, "travel")
     viz_manager = VisualizationManager()
 
-    with patch.object(ConverterTraveler, "travel") as mock_travel:
-        ConverterTraveler._get_if_body_viz_list(if_stmt_obj.body, viz_manager)
+    ConverterTraveler._get_if_body_viz_list(if_stmt_obj.body, viz_manager)
 
-        # travel 함수가 호출 되었는지 확인
-        mock_travel.assert_called_once_with(if_stmt_obj.body.body_steps, viz_manager)
+    # travel 함수가 호출 되었는지 확인
+    mock_travel.assert_called_once_with(if_stmt_obj.body.body_steps, viz_manager)
 
 
 def test__convert_to_flow_control_viz_pass_호출(mock_viz_manager_with_custom_depth):


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #160 

## 📝 작업 내용

- unitest의 mock에서 pytest의 목업을 사용

