### PR TITLE
[#156, 157, 158]feat, refactor: 리스트 append 기능 구현 및 call 함수 분리

### DIFF
--- a/app/visualize/analysis/stmt/models/assign_stmt_obj.py
+++ b/app/visualize/analysis/stmt/models/assign_stmt_obj.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Any
 
 from app.visualize.analysis.stmt.models.expr_stmt_obj import ExprStmtObj
 

--- a/app/visualize/analysis/stmt/parser/expr/expr_traveler.py
+++ b/app/visualize/analysis/stmt/parser/expr/expr_traveler.py
@@ -92,7 +92,7 @@ class ExprTraveler:
         return ListExpr.parse(elts)
 
     @staticmethod
-    def _compare_travel(node: ast.Compare, elem_container: ElementContainer):
+    def _compare_travel(node: ast, elem_container: ElementContainer):
         if isinstance(node, ast.Compare):
             left = ExprTraveler._compare_travel(node.left, elem_container)
             comparators = tuple(ExprTraveler._compare_travel(comparor, elem_container) for comparor in node.comparators)

--- a/app/visualize/analysis/stmt/parser/expr/models/expr_obj.py
+++ b/app/visualize/analysis/stmt/parser/expr/models/expr_obj.py
@@ -46,8 +46,8 @@ class ListObj(ExprObj):
 
 @dataclass(frozen=True)
 class RangeObj(ExprObj):
-    expressions: tuple[RangeExpression, ...]
     value: tuple
+    expressions: tuple[RangeExpression, ...]
     type: str = field(default="range", init=False)
 
 
@@ -75,4 +75,4 @@ class SliceObj(ExprObj):
 class AttributeObj(ExprObj):
     value: Any
     expressions: tuple[str, ...]
-    type: str = field(default="attribute", init=False)
+    type: str

--- a/app/visualize/analysis/stmt/parser/expr/models/expr_obj.py
+++ b/app/visualize/analysis/stmt/parser/expr/models/expr_obj.py
@@ -76,3 +76,10 @@ class AttributeObj(ExprObj):
     value: Any
     expressions: tuple[str, ...]
     type: str
+
+
+@dataclass(frozen=True)
+class AppendObj(ExprObj):
+    value: Any
+    expressions: tuple[str, ...]
+    type: str = field(default="append", init=False)

--- a/app/visualize/analysis/stmt/parser/expr/models/expr_obj.py
+++ b/app/visualize/analysis/stmt/parser/expr/models/expr_obj.py
@@ -69,3 +69,10 @@ class SliceObj(ExprObj):
     value: slice
     expressions = tuple[SliceExpression, ...]
     type: str = field(default="slice", init=False)
+
+
+@dataclass(frozen=True)
+class AttributeObj(ExprObj):
+    value: Any
+    expressions: tuple[str, ...]
+    type: str = field(default="attribute", init=False)

--- a/app/visualize/analysis/stmt/parser/expr/parser/attr_func/append_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/attr_func/append_expr.py
@@ -4,13 +4,24 @@ from app.visualize.analysis.stmt.parser.expr.models.expr_obj import AttributeObj
 class AppendExpr:
 
     @staticmethod
-    def parse(attr_obj: AttributeObj, args: list[ExprObj], keyword_arg_dict: dict):
-        pass
+    def parse(attr_obj: AttributeObj, args: list[ExprObj]):
+        AppendExpr._append_value(attr_obj, args)
+        value = AppendExpr._get_value(attr_obj)
+        expressions = AppendExpr._create_expressions(args)
+
+        return AttributeObj(value=value, expressions=expressions, type="append")
 
     @staticmethod
-    def _get_value(attr_obj: AttributeObj, args: list[ExprObj]):
-        pass
+    def _append_value(attr_obj: AttributeObj, args: list[ExprObj]):
+        append_method = attr_obj.value
+
+        append_method(*args)
 
     @staticmethod
-    def _create_expressions(attr_obj: AttributeObj, args: list[ExprObj]):
-        pass
+    def _get_value(attr_obj: AttributeObj):
+        return attr_obj.expressions[0]
+
+    @staticmethod
+    def _create_expressions(args: list[ExprObj]):
+
+        return args[0].expressions

--- a/app/visualize/analysis/stmt/parser/expr/parser/attr_func/append_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/attr_func/append_expr.py
@@ -1,27 +1,31 @@
-from app.visualize.analysis.stmt.parser.expr.models.expr_obj import AttributeObj, ExprObj
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import AttributeObj, ExprObj, AppendObj
 
 
 class AppendExpr:
 
     @staticmethod
     def parse(attr_obj: AttributeObj, args: list[ExprObj]):
-        AppendExpr._append_value(attr_obj, args)
-        value = AppendExpr._get_value(attr_obj)
-        expressions = AppendExpr._create_expressions(args)
+        if len(args) != 1:
+            raise ValueError(
+                f"[AppendExpr] append() 함수는 1개의 인자만 받을 수 있습니다. ({len(args)}개의 인자가 입력됨)"
+            )
 
-        return AttributeObj(value=value, expressions=expressions, type="append")
+        AppendExpr._append_value(attr_obj, args[0])
+        value = AppendExpr._get_value(attr_obj)
+        expressions = AppendExpr._create_expressions(args[0])
+
+        return AppendObj(value=value, expressions=expressions)
 
     @staticmethod
-    def _append_value(attr_obj: AttributeObj, args: list[ExprObj]):
+    def _append_value(attr_obj: AttributeObj, arg: ExprObj):
         append_method = attr_obj.value
 
-        append_method(*args)
+        append_method(arg.value)
 
     @staticmethod
     def _get_value(attr_obj: AttributeObj):
         return attr_obj.expressions[0]
 
     @staticmethod
-    def _create_expressions(args: list[ExprObj]):
-
-        return args[0].expressions
+    def _create_expressions(arg: ExprObj):
+        return arg.expressions

--- a/app/visualize/analysis/stmt/parser/expr/parser/attr_func/append_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/attr_func/append_expr.py
@@ -1,0 +1,16 @@
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import AttributeObj, ExprObj
+
+
+class AppendExpr:
+
+    @staticmethod
+    def parse(attr_obj: AttributeObj, args: list[ExprObj], keyword_arg_dict: dict):
+        pass
+
+    @staticmethod
+    def _get_value(attr_obj: AttributeObj, args: list[ExprObj]):
+        pass
+
+    @staticmethod
+    def _create_expressions(attr_obj: AttributeObj, args: list[ExprObj]):
+        pass

--- a/app/visualize/analysis/stmt/parser/expr/parser/attribute_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/attribute_expr.py
@@ -14,6 +14,7 @@ class AttributeExpr:
     def _get_value(target_obj: ExprObj, attr_name: str):
         target_value = target_obj.value
 
+        # getattr() 함수를 사용하여 target_value 객체의 attr_name 속성을 가져온다.
         return getattr(target_value, attr_name)
 
     @staticmethod

--- a/app/visualize/analysis/stmt/parser/expr/parser/attribute_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/attribute_expr.py
@@ -4,20 +4,18 @@ from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj, Att
 class AttributeExpr:
 
     @staticmethod
-    def parse(target_obj: ExprObj, attr_name: str, arg_objs: list[ExprObj, ...]):
-        value = AttributeExpr._get_value(target_obj, attr_name, arg_objs)
-        expressions = AttributeExpr._create_expressions(target_obj, value)
+    def parse(target_obj: ExprObj, attr_name: str):
+        value = AttributeExpr._get_value(target_obj, attr_name)
+        expressions = AttributeExpr._create_expressions(target_obj)
 
-        return AttributeObj(value=value, expressions=expressions)
+        return AttributeObj(value=value, expressions=expressions, type=attr_name)
 
     @staticmethod
-    def _get_value(target_obj: ExprObj, attr_name: str, arg_objs: list[ExprObj, ...]):
+    def _get_value(target_obj: ExprObj, attr_name: str):
         target_value = target_obj.value
 
-        getattr(target_value, attr_name)(*[arg.value for arg in arg_objs])
-
-        return target_value
+        return getattr(target_value, attr_name)
 
     @staticmethod
-    def _create_expressions(target_obj: ExprObj, value):
-        return tuple([target_obj.expressions[-1], str(value)])
+    def _create_expressions(target_obj: ExprObj):
+        return target_obj.expressions

--- a/app/visualize/analysis/stmt/parser/expr/parser/attribute_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/attribute_expr.py
@@ -1,6 +1,23 @@
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj, AttributeObj
+
+
 class AttributeExpr:
 
     @staticmethod
-    def parse(target, attr, args):
-        # Todo. AttributeExpr.parse() 메소드 구현
-        pass
+    def parse(target_obj: ExprObj, attr_name: str, arg_objs: list[ExprObj, ...]):
+        value = AttributeExpr._get_value(target_obj, attr_name, arg_objs)
+        expressions = AttributeExpr._create_expressions(target_obj, value)
+
+        return AttributeObj(value=value, expressions=expressions)
+
+    @staticmethod
+    def _get_value(target_obj: ExprObj, attr_name: str, arg_objs: list[ExprObj, ...]):
+        target_value = target_obj.value
+
+        getattr(target_value, attr_name)(*[arg.value for arg in arg_objs])
+
+        return target_value
+
+    @staticmethod
+    def _create_expressions(target_obj: ExprObj, value):
+        return tuple([target_obj.expressions[-1], str(value)])

--- a/app/visualize/analysis/stmt/parser/expr/parser/attribute_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/attribute_expr.py
@@ -1,0 +1,6 @@
+class AttributeExpr:
+
+    @staticmethod
+    def parse(target, attr, args):
+        # Todo. AttributeExpr.parse() 메소드 구현
+        pass

--- a/app/visualize/analysis/stmt/parser/expr/parser/built_in_func/print_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/built_in_func/print_expr.py
@@ -8,7 +8,7 @@ class PrintExpr:
     def parse(args: list[ExprObj], keyword_arg_dict: dict):
         key_word_dict = PrintExpr._create_keywords(keyword_arg_dict)
         expressions = PrintExpr._create_expressions(args, key_word_dict)
-        value = PrintExpr._get_value(args, key_word_dict)
+        value = PrintExpr._get_value(expressions, key_word_dict)
         return PrintObj(value=value, expressions=expressions)
 
         # print 함수의 키워드 파싱 : end, sep만 지원 Todo. file, flush

--- a/app/visualize/analysis/stmt/parser/expr/parser/built_in_func/print_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/built_in_func/print_expr.py
@@ -1,0 +1,40 @@
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj, PrintObj
+from app.visualize.utils import utils
+
+
+class PrintExpr:
+
+    @staticmethod
+    def parse(args: list[ExprObj], keyword_arg_dict: dict):
+        key_word_dict = PrintExpr._create_keywords(keyword_arg_dict)
+        expressions = PrintExpr._create_expressions(args, key_word_dict)
+        value = PrintExpr._get_value(args, key_word_dict)
+        return PrintObj(value=value, expressions=expressions)
+
+        # print 함수의 키워드 파싱 : end, sep만 지원 Todo. file, flush
+
+    @staticmethod
+    def _create_keywords(keyword_arg_dict: dict):
+        default_keyword = {"sep": " ", "end": "\n"}
+
+        for key, value in keyword_arg_dict.items():
+            default_keyword[key] = keyword_arg_dict[key]
+        return default_keyword
+
+    # ExprObj(type="print", value="abc 3\n", expressions=["abc a + 1\n", "abc 2 + 1\n", "abc 3\n"])
+    @staticmethod
+    def _create_expressions(args: list[ExprObj], key_word_dict: dict):
+        arg_expressions = [arg.expressions for arg in args]
+        transposed_expressions = utils.transpose_with_last_fill(arg_expressions)
+
+        print_expressions = []
+
+        for expressions in transposed_expressions:
+            str_expression = key_word_dict["sep"].join(expressions)
+            print_expressions.append(str_expression)
+
+        return tuple(print_expressions)
+
+    @staticmethod
+    def _get_value(print_expressions, key_word_dict: dict):
+        return print_expressions[-1] + key_word_dict["end"]

--- a/app/visualize/analysis/stmt/parser/expr/parser/built_in_func/print_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/built_in_func/print_expr.py
@@ -9,6 +9,7 @@ class PrintExpr:
         key_word_dict = PrintExpr._create_keywords(keyword_arg_dict)
         expressions = PrintExpr._create_expressions(args, key_word_dict)
         value = PrintExpr._get_value(expressions, key_word_dict)
+
         return PrintObj(value=value, expressions=expressions)
 
         # print 함수의 키워드 파싱 : end, sep만 지원 Todo. file, flush

--- a/app/visualize/analysis/stmt/parser/expr/parser/built_in_func/range_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/built_in_func/range_expr.py
@@ -1,0 +1,61 @@
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj, RangeObj
+from app.visualize.analysis.stmt.parser.expr.models.range_expression import RangeExpression
+from app.visualize.utils import utils
+
+
+class RangeExpr:
+
+    @staticmethod
+    def parse(args: list[ExprObj]):
+        value = RangeExpr._get_value([arg.value for arg in args])
+        expressions = RangeExpr._create_expressions([arg.expressions for arg in args])
+
+        return RangeObj(value=value, expressions=expressions)
+
+    @staticmethod
+    def _get_value(arg_value_list: list):
+        start = 0
+        step = 1
+
+        if len(arg_value_list) == 1:
+            end = arg_value_list[0]
+
+        elif len(arg_value_list) == 2:
+            start = arg_value_list[0]
+            end = arg_value_list[1]
+
+        elif len(arg_value_list) == 3:
+            start = arg_value_list[0]
+            end = arg_value_list[1]
+            step = arg_value_list[2]
+
+        else:
+            raise TypeError(f"[CallParser]: {arg_value_list} 인자의 개수가 잘못되었습니다.")
+
+        return tuple(range(int(start), int(end), int(step)))
+
+    @staticmethod
+    def _create_expressions(args_expressions: list[tuple]):
+
+        # utils의 transpose_with_last_fill을 이용하여 값 배열 생성
+        # ['a', '10', '2'], ['3', '10', '2']
+        transposed_expressions = utils.transpose_with_last_fill(args_expressions)
+
+        # 배열을 range_obj로 만들기
+        range_expressions = [RangeExpr._make_unit_range_expression(range_list) for range_list in transposed_expressions]
+
+        return tuple(range_expressions)
+
+    @staticmethod
+    def _make_unit_range_expression(range_list: list):
+        if len(range_list) == 1:
+            return RangeExpression(start="0", end=str(range_list[0]), step="1")
+
+        elif len(range_list) == 2:
+            return RangeExpression(start=str(range_list[0]), end=str(range_list[1]), step="1")
+
+        elif len(range_list) == 3:
+            return RangeExpression(start=str(range_list[0]), end=str(range_list[1]), step=str(range_list[2]))
+
+        else:
+            raise TypeError(f"[CallParser]: {range_list} 인자의 개수가 잘못되었습니다.")

--- a/app/visualize/analysis/stmt/parser/expr/parser/call_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/call_expr.py
@@ -29,7 +29,7 @@ class CallExpr:
             return range_obj
 
         else:
-            raise TypeError(f"[CallParser]: {func_name} is not defined.")
+            raise NotImplementedError(f"[CallParser]: {func_name} 은 아직 지원하지 않습니다.")
 
     @staticmethod
     def _attribute_call_parse(attr_obj: AttributeObj, args: list[ExprObj], keyword_arg_dict: dict):
@@ -37,3 +37,6 @@ class CallExpr:
         if attr_obj.type == "append":
             append_obj = AppendExpr.parse(attr_obj, args, keyword_arg_dict)
             return append_obj
+
+        else:
+            raise NotImplementedError(f"[CallParser]: {attr_obj.type} 은 아직 지원하지 않습니다.")

--- a/app/visualize/analysis/stmt/parser/expr/parser/call_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/call_expr.py
@@ -1,10 +1,7 @@
-from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj, RangeObj, PrintObj, AttributeObj
-from app.visualize.analysis.stmt.parser.expr.models.range_expression import RangeExpression
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj, AttributeObj
 from app.visualize.analysis.stmt.parser.expr.parser.attr_func.append_expr import AppendExpr
 from app.visualize.analysis.stmt.parser.expr.parser.built_in_func.print_expr import PrintExpr
 from app.visualize.analysis.stmt.parser.expr.parser.built_in_func.range_expr import RangeExpr
-
-from app.visualize.utils import utils
 
 
 class CallExpr:
@@ -16,10 +13,11 @@ class CallExpr:
             return CallExpr._built_in_call_parse(func_name, args, keyword_arg_dict)
 
         elif isinstance(func_name, AttributeObj):
-            return CallExpr._attribute_call_parse(func_name, args, keyword_arg_dict)
+            return CallExpr._attribute_call_parse(func_name, args)
 
     @staticmethod
     def _built_in_call_parse(func_name: str, args: list[ExprObj], keyword_arg_dict: dict):
+
         if func_name == "print":
             print_obj = PrintExpr.parse(args, keyword_arg_dict)
             return print_obj
@@ -32,10 +30,10 @@ class CallExpr:
             raise NotImplementedError(f"[CallParser]: {func_name} 은 아직 지원하지 않습니다.")
 
     @staticmethod
-    def _attribute_call_parse(attr_obj: AttributeObj, args: list[ExprObj], keyword_arg_dict: dict):
+    def _attribute_call_parse(attr_obj: AttributeObj, args: list[ExprObj]):
 
         if attr_obj.type == "append":
-            append_obj = AppendExpr.parse(attr_obj, args, keyword_arg_dict)
+            append_obj = AppendExpr.parse(attr_obj, args)
             return append_obj
 
         else:

--- a/app/visualize/analysis/stmt/parser/expr/parser/list_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/list_expr.py
@@ -23,4 +23,4 @@ class ListExpr:
         transposed_expression_lists = utils.transpose_with_last_fill(elts_expression_lists)
 
         # [("a + 1", "20"), ("10 + 1", "20"), ("11", "20")] -> ("[a + 1,20]", "[10 + 1,20]", "[11,20]")
-        return tuple(f"[{','.join(map(str, t))}]" for t in transposed_expression_lists)
+        return tuple(f"[{', '.join(map(str, t))}]" for t in transposed_expression_lists)

--- a/app/visualize/analysis/stmt/parser/expr/parser/slice_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/slice_expr.py
@@ -1,6 +1,5 @@
 from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj, SliceObj
 from app.visualize.analysis.stmt.parser.expr.models.slice_expression import SliceExpression
-from app.visualize.utils import utils
 
 
 class SliceExpr:

--- a/app/visualize/analysis/stmt/parser/expr/parser/subscript_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/subscript_expr.py
@@ -1,9 +1,6 @@
-import ast
 
 from app.visualize.analysis.stmt.parser.expr.models.expr_obj import (
     ExprObj,
-    ConstantObj,
-    NameObj,
     SliceObj,
     SubscriptObj,
 )

--- a/app/visualize/analysis/stmt/parser/expr/parser/subscript_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/subscript_expr.py
@@ -1,4 +1,3 @@
-
 from app.visualize.analysis.stmt.parser.expr.models.expr_obj import (
     ExprObj,
     SliceObj,

--- a/app/visualize/generator/converter/assign_converter.py
+++ b/app/visualize/generator/converter/assign_converter.py
@@ -3,19 +3,16 @@ from app.visualize.generator.highlight.expr_highlight import ExprHighlight
 from app.visualize.generator.highlight.list_highlight import ListHighlight
 from app.visualize.generator.models.assign_viz import AssignViz
 from app.visualize.generator.models.variable_vlz import Variable
-from app.visualize.generator.visualization_manager import VisualizationManager
 from app.visualize.utils import utils
 
 
 class AssignConverter:
     @staticmethod
-    def convert(assign_obj: AssignStmtObj, viz_manager: VisualizationManager):
-        depth = viz_manager.get_depth()
+    def convert(assign_obj: AssignStmtObj):
         expr_stmt_obj = assign_obj.expr_stmt_obj
         var_type = utils.get_var_type(expr_stmt_obj.value, expr_stmt_obj.expr_type)
-        highlights = AssignConverter._get_highlights(expr_stmt_obj, var_type)
 
-        return AssignConverter._convert_to_assign_viz(expr_stmt_obj, assign_obj.targets, depth, highlights, var_type)
+        return AssignConverter._convert_to_assign_viz(expr_stmt_obj, assign_obj.targets, var_type)
 
     @staticmethod
     def _get_highlights(expr_stmt_obj, var_type):
@@ -25,13 +22,11 @@ class AssignConverter:
             return ListHighlight.get_highlight_indexes(expr_stmt_obj.expressions)
 
     @staticmethod
-    def _convert_to_assign_viz(expr_stmt_obj, targets, depth, highlights, var_type):
+    def _convert_to_assign_viz(expr_stmt_obj, targets, var_type):
         variable_list = [
             Variable(
                 id=expr_stmt_obj.id,
-                depth=depth,
                 expr=expr_stmt_obj.expressions[-1],
-                highlights=highlights[-1],
                 name=target,
                 type=var_type,
             )

--- a/app/visualize/generator/converter/expr_converter.py
+++ b/app/visualize/generator/converter/expr_converter.py
@@ -3,7 +3,6 @@ from app.visualize.generator.highlight.expr_highlight import ExprHighlight
 from app.visualize.generator.models.append_viz import AppendViz
 from app.visualize.generator.models.expr_viz import ExprViz
 from app.visualize.generator.models.print_viz import PrintViz
-from app.visualize.generator.highlight.list_highlight import ListHighlight
 from app.visualize.generator.models.variable_vlz import Variable
 from app.visualize.generator.visualization_manager import VisualizationManager
 from app.visualize.utils import utils
@@ -34,17 +33,11 @@ class ExprConverter:
 
     @staticmethod
     def _convert_to_expr_viz(expr_stmt_obj: ExprStmtObj, var_type, call_id, depth):
-        if var_type == "list":
-            highlights = ListHighlight.get_highlight_indexes(expr_stmt_obj.expressions)
-        else:
-            highlights = ExprHighlight.get_highlight_indexes(expr_stmt_obj.expressions)
-
         expr_vizs = [
             ExprViz(
                 id=call_id,
                 depth=depth,
                 expr=expr_stmt_obj.expressions[idx],
-                highlights=highlights[idx],
                 type=var_type,
             )
             for idx in range(len(expr_stmt_obj.expressions))

--- a/app/visualize/generator/converter/expr_converter.py
+++ b/app/visualize/generator/converter/expr_converter.py
@@ -1,8 +1,10 @@
 from app.visualize.analysis.stmt.models.expr_stmt_obj import ExprStmtObj
 from app.visualize.generator.highlight.expr_highlight import ExprHighlight
+from app.visualize.generator.models.append_viz import AppendViz
 from app.visualize.generator.models.expr_viz import ExprViz
 from app.visualize.generator.models.print_viz import PrintViz
 from app.visualize.generator.highlight.list_highlight import ListHighlight
+from app.visualize.generator.models.variable_vlz import Variable
 from app.visualize.generator.visualization_manager import VisualizationManager
 from app.visualize.utils import utils
 
@@ -23,6 +25,9 @@ class ExprConverter:
 
         elif var_type == "print":
             return ExprConverter._convert_to_print_viz(expr_stmt_obj, call_id, depth)
+
+        elif var_type == "append":
+            return ExprConverter._convert_to_append_viz(expr_stmt_obj, call_id, depth)
 
         else:
             raise TypeError(f"[ExprConverter]:{var_type}는 지원하지 않습니다.")
@@ -63,3 +68,23 @@ class ExprConverter:
         ]
 
         return print_vizs
+
+    @staticmethod
+    def _convert_to_append_viz(expr_stmt_obj: ExprStmtObj, call_id, depth):
+        append_vizs = []
+        var_type = utils.check_list(expr_stmt_obj.expressions[-1])
+        expr_vizs = ExprConverter._convert_to_expr_viz(expr_stmt_obj, var_type, call_id, depth)
+        append_vizs.extend(expr_vizs)
+
+        append_vizs.append(
+            AppendViz(
+                variable=Variable(
+                    id=call_id,
+                    expr=expr_stmt_obj.expressions[-1],
+                    name=expr_stmt_obj.value,
+                    type=var_type,
+                ),
+            )
+        )
+
+        return append_vizs

--- a/app/visualize/generator/converter/if_converter.py
+++ b/app/visualize/generator/converter/if_converter.py
@@ -2,7 +2,6 @@ from app.visualize.analysis.stmt.models.if_stmt_obj import (
     ConditionObj,
     IfConditionObj,
     ElifConditionObj,
-    ElseConditionObj,
 )
 from app.visualize.generator.models.if_viz import ConditionViz, IfElseDefineViz, IfElseChangeViz
 from app.visualize.generator.visualization_manager import VisualizationManager

--- a/app/visualize/generator/converter_traveler.py
+++ b/app/visualize/generator/converter_traveler.py
@@ -36,7 +36,7 @@ class ConverterTraveler:
     def _convert_to_assign_vizs(assign_obj: AssignStmtObj, viz_manager: VisualizationManager):
         steps = []
         steps.extend(ConverterTraveler._convert_to_expr_vizs(assign_obj.expr_stmt_obj, viz_manager))
-        steps.append(AssignConverter.convert(assign_obj, viz_manager))
+        steps.append(AssignConverter.convert(assign_obj))
 
         return steps
 

--- a/app/visualize/generator/models/append_viz.py
+++ b/app/visualize/generator/models/append_viz.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+from app.visualize.generator.models.variable_vlz import Variable
+
+
+@dataclass(frozen=True)
+class AppendViz:
+    variable: Variable
+    type: str = "appendViz"

--- a/app/visualize/generator/models/expr_viz.py
+++ b/app/visualize/generator/models/expr_viz.py
@@ -6,5 +6,4 @@ class ExprViz:
     id: int
     depth: int
     expr: str
-    highlights: []
     type: str

--- a/app/visualize/generator/models/variable_vlz.py
+++ b/app/visualize/generator/models/variable_vlz.py
@@ -4,10 +4,8 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class Variable:
     id: int
-    depth: int
     expr: str
     name: str
-    highlights: list
     type: str
 
 

--- a/app/visualize/utils/utils.py
+++ b/app/visualize/utils/utils.py
@@ -25,14 +25,22 @@ def get_var_type(var_value, obj_type: str):
         return "variable"
 
     elif obj_type == "name" or obj_type == "subscript":
-        if isinstance(var_value, list):
-            return "list"
-
-        else:
-            return "variable"
+        return check_list(var_value)
 
     elif obj_type == "list":
         return "list"
 
     else:
         return obj_type
+
+
+def check_list(var_value):
+    if isinstance(var_value, list) or is_list(var_value):
+        return "list"
+
+    else:
+        return "variable"
+
+
+def is_list(var_value):
+    return var_value.startswith("[") and var_value.endswith("]")

--- a/tests/visualize/analysis/stmt/parser/expr/parser/attr_func/test_append_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/attr_func/test_append_expr.py
@@ -1,0 +1,127 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import (
+    AttributeObj,
+    ExprObj,
+    ConstantObj,
+    NameObj,
+    AppendObj,
+)
+from app.visualize.analysis.stmt.parser.expr.parser.attr_func.append_expr import AppendExpr
+
+
+@pytest.mark.parametrize(
+    "elem_container_dict, expressions, args, expected",
+    [
+        pytest.param(
+            {"a": [1, 2, 3, 4, 5]},
+            ("a", "[1, 2, 3, 4, 5]"),
+            [ConstantObj(value=10, expressions=("10",))],
+            AppendObj(value="a", expressions=("10",)),
+            id="a.append(10): success case",
+        ),
+        pytest.param(
+            {"a": [1, 2, 3, 4, 5]},
+            ("a", "[1, 2, 3, 4, 5]"),
+            [ConstantObj(value=10, expressions=("b + 1", "10 + 1", "11"))],
+            AppendObj(value="a", expressions=("b + 1", "10 + 1", "11")),
+            id="a.append(b + 1): success case",
+        ),
+    ],
+)
+def test_parse(mocker, elem_container_dict: dict, expressions: tuple, args: list[ExprObj], expected: AttributeObj):
+    mock_get_value = mocker.patch.object(AppendExpr, "_get_value", return_value=expected.value)
+    mock_create_expressions = mocker.patch.object(AppendExpr, "_create_expressions", return_value=expected.expressions)
+
+    attr_obj = AttributeObj(
+        value=getattr(elem_container_dict["a"], "append"),
+        expressions=expressions,
+        type="append",
+    )
+
+    result = AppendExpr.parse(attr_obj, args)
+
+    assert isinstance(result, AppendObj)
+    mock_get_value.assert_called_once_with(attr_obj)
+    mock_create_expressions.assert_called_once_with(args[0])
+
+
+def test_parse_wrong_arguments():
+    attr_obj = MagicMock(spec=AttributeObj)
+    args = [MagicMock(spec=ExprObj), MagicMock(spec=ExprObj)]
+
+    with pytest.raises(ValueError):
+        AppendExpr.parse(attr_obj, args)
+
+
+@pytest.mark.parametrize(
+    "elem_container_dict, expressions, arg",
+    [
+        pytest.param(
+            {"a": [1, 2, 3, 4, 5]},
+            ("a", "[1, 2, 3, 4, 5]"),
+            ConstantObj(value=10, expressions=("10",)),
+            id="a.append(10): success case",
+        ),
+        pytest.param(
+            {"a": [1, 2, 3, 4, 5]},
+            ("a", "[1, 2, 3, 4, 5]"),
+            NameObj(value=11, expressions=("b + 1", "10 + 1", "11")),
+            id="a.append(b + 1): success case",
+        ),
+    ],
+)
+def test_append_value(elem_container_dict: dict, expressions: tuple, arg: ExprObj):
+    attr_obj = AttributeObj(
+        value=getattr(elem_container_dict["a"], "append"),
+        expressions=expressions,
+        type="append",
+    )
+    AppendExpr._append_value(attr_obj, arg)
+
+    assert elem_container_dict["a"] == [1, 2, 3, 4, 5, arg.value]
+
+
+@pytest.mark.parametrize(
+    "elem_container_dict, expressions, expected",
+    [
+        pytest.param(
+            {"a": [1, 2, 3, 4, 5]},
+            ("a", "[1, 2, 3, 4, 5]"),
+            "a",
+            id="a.append(10): success case",
+        )
+    ],
+)
+def test_get_value(elem_container_dict: dict, expressions: tuple, expected: str):
+    attr_obj = AttributeObj(
+        value=getattr(elem_container_dict["a"], "append"),
+        expressions=expressions,
+        type="append",
+    )
+    result = AppendExpr._get_value(attr_obj)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "arg, expected",
+    [
+        pytest.param(
+            ConstantObj(value=10, expressions=("10",)),
+            ("10",),
+            id="a.append(10): success case",
+        ),
+        pytest.param(
+            NameObj(value=11, expressions=("b + 1", "10 + 1", "11")),
+            ("b + 1", "10 + 1", "11"),
+            id="a.append(b + 1): success case",
+        ),
+    ],
+)
+def test_create_expressions(arg: ExprObj, expected):
+    result = AppendExpr._create_expressions(arg)
+
+    assert result == expected

--- a/tests/visualize/analysis/stmt/parser/expr/parser/built_in_func/test_print_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/built_in_func/test_print_expr.py
@@ -1,0 +1,162 @@
+import pytest
+
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ConstantObj, BinopObj, PrintObj, ExprObj
+from app.visualize.analysis.stmt.parser.expr.parser.built_in_func.print_expr import PrintExpr
+
+
+@pytest.mark.parametrize(
+    "args, keyword_arg_dict, expected",
+    [
+        pytest.param(
+            [ConstantObj(value="abc", expressions=("abc",))],
+            {},
+            PrintObj(value="abc\n", expressions=("abc",)),
+            id="print('abc'): success case",
+        ),
+        pytest.param(
+            [BinopObj(value="'****'", expressions=("'*' * 4", "'****'"))],
+            {},
+            PrintObj(value="****\n", expressions=("'*' * 4", "'****'")),
+            id="print('*' * 4): success case",
+        ),
+        pytest.param(
+            [ConstantObj(value="abc", expressions=("abc",))],
+            {"end": " "},
+            PrintObj(value="abc ", expressions=("abc",)),
+            id="print('abc', end=' '): success case",
+        ),
+        pytest.param(
+            [ConstantObj(value="abc", expressions=("abc",)), ConstantObj(value="def", expressions=("def",))],
+            {},
+            PrintObj(value="abc def\n", expressions=("abc def",)),
+            id="print('abc', 'def'): success case",
+        ),
+        pytest.param(
+            [ConstantObj(value="abc", expressions=("abc",)), ConstantObj(value="def", expressions=("def",))],
+            {"sep": "-"},
+            PrintObj(value="abc-def\n", expressions=("abc-def",)),
+            id="print('abc', 'def', sep='-'): success case",
+        ),
+    ],
+)
+def test_parse(mocker, args: list[ExprObj], keyword_arg_dict: dict, expected: PrintObj):
+    mock_get_value = mocker.patch.object(PrintExpr, "_get_value", return_value=expected.value)
+    mock_create_expressions = mocker.patch.object(PrintExpr, "_create_expressions", return_value=expected.expressions)
+
+    result = PrintExpr.parse(args, keyword_arg_dict)
+
+    assert isinstance(result, PrintObj)
+    assert mock_get_value.called_once_with(args, keyword_arg_dict)
+    assert mock_create_expressions.called_once_with(args, keyword_arg_dict)
+
+
+@pytest.mark.parametrize(
+    "keyword_arg_dict, expected",
+    [
+        pytest.param(
+            {},
+            {"sep": " ", "end": "\n"},
+            id="default keyword: success case",
+        ),
+        pytest.param(
+            {"sep": "-"},
+            {"sep": "-", "end": "\n"},
+            id="sep='-': success case",
+        ),
+        pytest.param(
+            {"end": " "},
+            {"sep": " ", "end": " "},
+            id="end=' ': success case",
+        ),
+        pytest.param(
+            {"sep": "-", "end": " "},
+            {"sep": "-", "end": " "},
+            id="sep='-', end=' ': success case",
+        ),
+    ],
+)
+def test_create_keywords(keyword_arg_dict: dict, expected: PrintObj):
+    result = PrintExpr._create_keywords(keyword_arg_dict)
+
+    assert isinstance(result, dict)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "args, keyword_arg_dict, expected",
+    [
+        pytest.param(
+            [ConstantObj(value="abc", expressions=("abc",))],
+            {"sep": " ", "end": "\n"},
+            ("abc",),
+            id="print('abc'): success case",
+        ),
+        pytest.param(
+            [BinopObj(value="'****'", expressions=("'*' * 4", "'****'"))],
+            {"sep": " ", "end": "\n"},
+            ("'*' * 4", "'****'"),
+            id="print('*' * 4): success case",
+        ),
+        pytest.param(
+            [ConstantObj(value="abc", expressions=("abc",))],
+            {"sep": " ", "end": " "},
+            ("abc",),
+            id="print('abc', end=' '): success case",
+        ),
+        pytest.param(
+            [ConstantObj(value="abc", expressions=("abc",)), ConstantObj(value="def", expressions=("def",))],
+            {"sep": " ", "end": "\n"},
+            ("abc def",),
+            id="print('abc', 'def'): success case",
+        ),
+        pytest.param(
+            [ConstantObj(value="abc", expressions=("abc",)), ConstantObj(value="def", expressions=("def",))],
+            {"sep": "-", "end": "\n"},
+            ("abc-def",),
+            id="print('abc', 'def', sep='-'): success case",
+        ),
+    ],
+)
+def test_create_expressions(args: list[ExprObj], keyword_arg_dict: dict, expected: tuple[str]):
+    result = PrintExpr._create_expressions(args, keyword_arg_dict)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "print_expressions, keyword_arg_dict, expected",
+    [
+        pytest.param(
+            ("abc",),
+            {"sep": " ", "end": "\n"},
+            "abc\n",
+            id="print('abc'): success case",
+        ),
+        pytest.param(
+            ("'*' * 4", "'****'"),
+            {"sep": " ", "end": "\n"},
+            "'****'\n",
+            id="print('*' * 4): success case",
+        ),
+        pytest.param(
+            ("abc",),
+            {"sep": " ", "end": " "},
+            "abc ",
+            id="print('abc', end=' '): success case",
+        ),
+        pytest.param(
+            ("abc def",),
+            {"sep": " ", "end": "\n"},
+            "abc def\n",
+            id="print('abc', 'def'): success case",
+        ),
+        pytest.param(
+            ("abc-def",),
+            {"sep": "-", "end": "\n"},
+            "abc-def\n",
+            id="print('abc', 'def', sep='-'): success case",
+        ),
+    ],
+)
+def test_get_value(print_expressions: tuple[str], keyword_arg_dict: dict, expected: PrintObj):
+    PrintExpr._get_value(print_expressions, keyword_arg_dict)

--- a/tests/visualize/analysis/stmt/parser/expr/parser/built_in_func/test_range_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/built_in_func/test_range_expr.py
@@ -1,0 +1,139 @@
+import pytest
+
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj, RangeObj, ConstantObj, NameObj
+from app.visualize.analysis.stmt.parser.expr.models.range_expression import RangeExpression
+from app.visualize.analysis.stmt.parser.expr.parser.built_in_func.range_expr import RangeExpr
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        pytest.param(
+            [ConstantObj(value=5, expressions=("5",))],
+            RangeObj(value=tuple(range(0, 5, 1)), expressions=(RangeExpression(start="0", end="5", step="1"),)),
+            id="range(5): success case",
+        ),
+        pytest.param(
+            [ConstantObj(value=1, expressions=("1",)), ConstantObj(value=5, expressions=("5",))],
+            RangeObj(value=tuple(range(1, 5, 1)), expressions=(RangeExpression(start="1", end="5", step="1"),)),
+            id="range(1, 5): success case",
+        ),
+        pytest.param(
+            [ConstantObj(value=1, expressions=("1",)), NameObj(value=5, expressions=("a", "5"))],
+            RangeObj(
+                value=tuple(range(1, 5, 1)),
+                expressions=(
+                    RangeExpression(start="1", end="a", step="1"),
+                    RangeExpression(start="1", end="5", step="1"),
+                ),
+            ),
+            id="range(1, a): success case",
+        ),
+        pytest.param(
+            [
+                ConstantObj(value=1, expressions=("1",)),
+                ConstantObj(value=5, expressions=("5",)),
+                ConstantObj(value=2, expressions=("2",)),
+            ],
+            RangeObj(value=tuple(range(1, 5, 2)), expressions=(RangeExpression(start="1", end="5", step="2"),)),
+            id="range(1, 5, 2): success case",
+        ),
+    ],
+)
+def test_parse(mocker, args: list[ExprObj], expected: RangeObj):
+    mock_get_value = mocker.patch.object(RangeExpr, "_get_value", return_value=expected.value)
+    mock_create_expressions = mocker.patch.object(RangeExpr, "_create_expressions", return_value=expected.expressions)
+
+    result = RangeExpr.parse(args)
+
+    assert isinstance(result, RangeObj)
+    assert mock_get_value.called_once_with([arg.value for arg in args])
+    assert mock_create_expressions.called_once_with([arg.expressions for arg in args])
+
+
+@pytest.mark.parametrize(
+    "arg_value_list, expected",
+    [
+        pytest.param(
+            [5],
+            tuple(range(0, 5, 1)),
+            id="range(5): success case",
+        ),
+        pytest.param(
+            [1, 5],
+            tuple(range(1, 5, 1)),
+            id="range(1, 5): success case",
+        ),
+        pytest.param(
+            [1, 5, 2],
+            tuple(range(1, 5, 2)),
+            id="range(1, 5, 2): success case",
+        ),
+    ],
+)
+def test_get_value(arg_value_list: list, expected):
+    result = RangeExpr._get_value(arg_value_list)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "args_expressions, expected",
+    [
+        pytest.param(
+            [("5",)],
+            (RangeExpression(start="0", end="5", step="1"),),
+            id="range(5): success case",
+        ),
+        pytest.param(
+            [("a", "5")],
+            (RangeExpression(start="0", end="a", step="1"), RangeExpression(start="0", end="5", step="1")),
+            id="range(a): success case",
+        ),
+        pytest.param(
+            [("1",), ("a", "5")],
+            (RangeExpression(start="1", end="a", step="1"), RangeExpression(start="1", end="5", step="1")),
+            id="range(1, a): success case",
+        ),
+        pytest.param(
+            [("1",), ("a", "5"), ("2",)],
+            (RangeExpression(start="1", end="a", step="2"), RangeExpression(start="1", end="5", step="2")),
+            id="range(1, a, 2): success case",
+        ),
+    ],
+)
+def test_create_expressions(args_expressions: list[tuple], expected):
+    result = RangeExpr._create_expressions(args_expressions)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "range_list, expected",
+    [
+        pytest.param(
+            [5],
+            RangeExpression(start="0", end="5", step="1"),
+            id="range(5): success case",
+        ),
+        pytest.param(
+            [1, 5],
+            RangeExpression(start="1", end="5", step="1"),
+            id="range(1, 5): success case",
+        ),
+        pytest.param(
+            [1, 5, 2],
+            RangeExpression(start="1", end="5", step="2"),
+            id="range(1, 5, 2): success case",
+        ),
+    ],
+)
+def test_make_unit_range_expression(range_list: list, expected):
+    result = RangeExpr._make_unit_range_expression(range_list)
+
+    assert result == expected
+
+
+def test_make_unit_range_expression_fail():
+    with pytest.raises(TypeError):
+        RangeExpr._make_unit_range_expression([1, 2, 3, 4])

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_attribute_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_attribute_expr.py
@@ -1,23 +1,29 @@
 import pytest
 
-from app.visualize.analysis.stmt.parser.expr.models.expr_obj import NameObj, ConstantObj, AttributeObj
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import NameObj, ConstantObj, AttributeObj, ExprObj, ListObj
 from app.visualize.analysis.stmt.parser.expr.parser.attribute_expr import AttributeExpr
 
 
 @pytest.mark.parametrize(
-    "target, attr, args, expected",
+    "target_obj, attr_name, arg_objs, expected",
     [
         pytest.param(
-            NameObj(value="a", expressions=("a", "[1, 2, 3, 4, 5]")),
+            NameObj(value=[1, 2, 3, 4, 5], expressions=("a", "[1, 2, 3, 4, 5]")),
             "append",
             [ConstantObj(value=10, expressions=("10",))],
-            AttributeObj(value="[1, 2, 3, 4, 5, 10]", expressions=("[1, 2, 3, 4, 5]", "[1, 2, 3, 4, 5, 10]")),
+            AttributeObj(value=[1, 2, 3, 4, 5, 10], expressions=("[1, 2, 3, 4, 5]", "[1, 2, 3, 4, 5, 10]")),
             id="a.append(10): success case",
         ),
-        # Todo. 테스트 케이스 추가
+        pytest.param(
+            ListObj(value=[1, 2, 3, 4, 5], expressions=("[1, 2, 3, 4, 5]",)),
+            "append",
+            [ConstantObj(value=10, expressions=("10",))],
+            AttributeObj(value=[1, 2, 3, 4, 5, 10], expressions=("[1, 2, 3, 4, 5]", "[1, 2, 3, 4, 5, 10]")),
+            id="[1, 2, 3, 4, 5].append(10): success case",
+        ),
     ],
 )
-def test_parse_append_case(target, attr, args, expected):
-    result = AttributeExpr.parse(target, attr, args)
+def test_parse_append_case(target_obj: ExprObj, attr_name: str, arg_objs: list[ExprObj, ...], expected):
+    result = AttributeExpr.parse(target_obj, attr_name, arg_objs)
 
     assert result == expected

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_attribute_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_attribute_expr.py
@@ -3,27 +3,27 @@ import pytest
 from app.visualize.analysis.stmt.parser.expr.models.expr_obj import NameObj, ConstantObj, AttributeObj, ExprObj, ListObj
 from app.visualize.analysis.stmt.parser.expr.parser.attribute_expr import AttributeExpr
 
+target_list = [1, 2, 3, 4, 5]
+
 
 @pytest.mark.parametrize(
-    "target_obj, attr_name, arg_objs, expected",
+    "target_obj, attr_name, expected",
     [
         pytest.param(
-            NameObj(value=[1, 2, 3, 4, 5], expressions=("a", "[1, 2, 3, 4, 5]")),
+            NameObj(value=target_list, expressions=("a", "[1, 2, 3, 4, 5]")),
             "append",
-            [ConstantObj(value=10, expressions=("10",))],
-            AttributeObj(value=[1, 2, 3, 4, 5, 10], expressions=("[1, 2, 3, 4, 5]", "[1, 2, 3, 4, 5, 10]")),
+            AttributeObj(value=getattr(target_list, "append"), expressions=("a", "[1, 2, 3, 4, 5]"), type="append"),
             id="a.append(10): success case",
         ),
         pytest.param(
-            ListObj(value=[1, 2, 3, 4, 5], expressions=("[1, 2, 3, 4, 5]",)),
+            ListObj(value=target_list, expressions=("[1, 2, 3, 4, 5]",)),
             "append",
-            [ConstantObj(value=10, expressions=("10",))],
-            AttributeObj(value=[1, 2, 3, 4, 5, 10], expressions=("[1, 2, 3, 4, 5]", "[1, 2, 3, 4, 5, 10]")),
+            AttributeObj(value=getattr(target_list, "append"), expressions=("[1, 2, 3, 4, 5]",), type="append"),
             id="[1, 2, 3, 4, 5].append(10): success case",
         ),
     ],
 )
-def test_parse_append_case(target_obj: ExprObj, attr_name: str, arg_objs: list[ExprObj, ...], expected):
-    result = AttributeExpr.parse(target_obj, attr_name, arg_objs)
+def test_parse_append_case(target_obj: ExprObj, attr_name: str, expected):
+    result = AttributeExpr.parse(target_obj, attr_name)
 
     assert result == expected

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_attribute_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_attribute_expr.py
@@ -1,0 +1,23 @@
+import pytest
+
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import NameObj, ConstantObj, AttributeObj
+from app.visualize.analysis.stmt.parser.expr.parser.attribute_expr import AttributeExpr
+
+
+@pytest.mark.parametrize(
+    "target, attr, args, expected",
+    [
+        pytest.param(
+            NameObj(value="a", expressions=("a", "[1, 2, 3, 4, 5]")),
+            "append",
+            [ConstantObj(value=10, expressions=("10",))],
+            AttributeObj(value="[1, 2, 3, 4, 5, 10]", expressions=("[1, 2, 3, 4, 5]", "[1, 2, 3, 4, 5, 10]")),
+            id="a.append(10): success case",
+        ),
+        # Todo. 테스트 케이스 추가
+    ],
+)
+def test_parse_append_case(target, attr, args, expected):
+    result = AttributeExpr.parse(target, attr, args)
+
+    assert result == expected

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_call_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_call_expr.py
@@ -1,271 +1,48 @@
 import pytest
 
-from app.visualize.analysis.stmt.parser.expr.models.expr_obj import (
-    ExprObj,
-    ConstantObj,
-    NameObj,
-    BinopObj,
-    PrintObj,
-    RangeObj,
-)
-from app.visualize.analysis.stmt.parser.expr.models.range_expression import RangeExpression
-from app.visualize.analysis.stmt.parser.expr.parser.call_expr import CallExpr
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import AttributeObj, ExprObj
 
 
 @pytest.mark.parametrize(
     "func_name, args, keyword_arg_dict, expected",
     [
         pytest.param(
-            "print",
-            [ConstantObj(value="abc", expressions=("abc",))],
-            {},
-            PrintObj(value="abc\n", expressions=("abc",)),
-            id="print('abc'): success case",
+            id="Built-in-function print: success case",
         ),
         pytest.param(
-            "print",
-            [BinopObj(value="'****'", expressions=("'*' * 4", "'****'"))],
-            {},
-            PrintObj(value="****\n", expressions=("'*' * 4", "'****'")),
-            id="print('*' * 4): success case",
+            id="Built-in-function range: success case",
         ),
         pytest.param(
-            "print",
-            [ConstantObj(value="abc", expressions=("abc",))],
-            {"end": " "},
-            PrintObj(value="abc ", expressions=("abc",)),
-            id="print('abc', end=' '): success case",
-        ),
-        pytest.param(
-            "print",
-            [ConstantObj(value="abc", expressions=("abc",)), ConstantObj(value="def", expressions=("def",))],
-            {},
-            PrintObj(value="abc def\n", expressions=("abc def",)),
-            id="print('abc', 'def'): success case",
-        ),
-        pytest.param(
-            "print",
-            [ConstantObj(value="abc", expressions=("abc",)), ConstantObj(value="def", expressions=("def",))],
-            {"sep": "-"},
-            PrintObj(value="abc-def\n", expressions=("abc-def",)),
-            id="print('abc', 'def', sep='-'): success case",
+            id="attribute-function append: success case",
         ),
     ],
 )
-def test_parse_case_print(mocker, func_name: str, args: list[ExprObj], keyword_arg_dict: dict, expected: PrintObj):
-    mock_print_parse = mocker.patch.object(
-        CallExpr,
-        "_print_parse",
-        return_value=(expected.value, expected.expressions),
-    )
-    result = CallExpr.parse(func_name, args, keyword_arg_dict)
-
-    assert isinstance(result, PrintObj)
-    assert mock_print_parse.called_once_with(args, keyword_arg_dict)
+def test_parse(func_name: str | AttributeObj, args: list[ExprObj], keyword_arg_dict: dict):
+    pass
 
 
 @pytest.mark.parametrize(
-    "func_name, args, expected",
+    "func_name, args, keyword_arg_dict, expected",
     [
         pytest.param(
-            "range",
-            [ConstantObj(value=10, expressions=("10",))],
-            RangeObj(
-                value=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), expressions=(RangeExpression(start="0", end="10", step="1"),)
-            ),
-            id="range(10): success case",
+            id="Built-in-function print: success case",
         ),
         pytest.param(
-            "range",
-            [NameObj(value=10, expressions=("a", "10"))],
-            RangeObj(
-                value=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
-                expressions=(
-                    RangeExpression(start="0", end="a", step="1"),
-                    RangeExpression(start="0", end="10", step="1"),
-                ),
-            ),
-            id="range(a): success case",
-        ),
-        pytest.param(
-            "range",
-            [ConstantObj(value=2, expressions=("2",)), ConstantObj(value=10, expressions=("10",))],
-            RangeObj(value=(2, 3, 4, 5, 6, 7, 8, 9), expressions=(RangeExpression(start="2", end="10", step="1"),)),
-            id="range(2, 10): success case",
-        ),
-        pytest.param(
-            "range",
-            [
-                ConstantObj(value=2, expressions=("2",)),
-                ConstantObj(value=10, expressions=("10",)),
-                ConstantObj(value=2, expressions=("2",)),
-            ],
-            RangeObj(value=(2, 4, 6, 8), expressions=(RangeExpression(start="2", end="10", step="1"),)),
-            id="range(2, 10, 2): success case",
+            id="Built-in-function range: success case",
         ),
     ],
 )
-def test_parse_case_range(mocker, func_name: str, args: list[ExprObj], expected: RangeObj):
-    keyword_arg_dict = {}
-    mock_range_parse = mocker.patch.object(
-        CallExpr,
-        "_range_parse",
-        return_value=(expected.value, expected.expressions),
-    )
-    result = CallExpr.parse(func_name, args, keyword_arg_dict)
-
-    assert isinstance(result, RangeObj)
-    assert mock_range_parse.called_once_with(args, keyword_arg_dict)
+def test_built_in_call_parse(func_name: str, args: list[ExprObj], keyword_arg_dict: dict):
+    pass
 
 
 @pytest.mark.parametrize(
-    "args, keyword_arg_dict, expected",
+    "attr_obj, args, keyword_arg_dict, expected",
     [
         pytest.param(
-            [ConstantObj(value="abc", expressions=("abc",))], {}, ("abc\n", ("abc",)), id="print('abc'): success case"
-        ),
-        pytest.param(
-            [
-                ConstantObj(value="abc", expressions=("abc",)),
-                ConstantObj(value=1, expressions=("1",)),
-            ],
-            {},
-            ("abc 1\n", ("abc 1",)),
-            id="print(abc, 1): success case",
-        ),
-        pytest.param(
-            [
-                ConstantObj(value="abc", expressions=("abc",)),
-                NameObj(value=3, expressions=("a", "3")),
-            ],
-            {},
-            (
-                "abc 3\n",
-                (
-                    "abc a",
-                    "abc 3",
-                ),
-            ),
-            id="print(abc, a): success case",
-        ),
-        pytest.param(
-            [
-                ConstantObj(value="abc", expressions=("abc",)),
-                BinopObj(value=3, expressions=("a + 1", "2 + 1", "3")),
-            ],
-            {},
-            ("abc 3\n", ("abc a + 1", "abc 2 + 1", "abc 3")),
-            id="print(abc,a + 1): success case",
-        ),
-        pytest.param(
-            [
-                ConstantObj(value="abc", expressions=("abc",)),
-                NameObj(value=3, expressions=("a", "3")),
-            ],
-            {"sep": "-"},
-            (
-                "abc-3\n",
-                (
-                    "abc-a",
-                    "abc-3",
-                ),
-            ),
-            id="print(abc, a, sep='-'): success case",
+            id="attribute-function append: success case",
         ),
     ],
 )
-def test_print_parse(args: list[ExprObj], keyword_arg_dict: dict, expected):
-    result = CallExpr._print_parse(args, keyword_arg_dict)
-
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    "default_keyword, keyword_arg_dict, expected",
-    [
-        pytest.param({"sep": " ", "end": "\n"}, {}, {"sep": " ", "end": "\n"}, id="default: success case"),
-        pytest.param({"sep": " ", "end": "\n"}, {"sep": "-"}, {"sep": "-", "end": "\n"}, id="sep:'-': success case"),
-        pytest.param({"sep": " ", "end": "\n"}, {"end": " "}, {"sep": " ", "end": " "}, id="end:' ': success case"),
-        pytest.param(
-            {"sep": " ", "end": "\n"},
-            {"sep": "-", "end": " "},
-            {"sep": "-", "end": " "},
-            id="sep:'-', end:' ': success case",
-        ),
-    ],
-)
-def test_apply_keywords(default_keyword: dict, keyword_arg_dict: dict, expected):
-    result = CallExpr._apply_keywords(default_keyword, keyword_arg_dict)
-
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    "expressions, expected_iter, expected_expressions",
-    [
-        pytest.param(
-            [
-                NameObj(value=10, expressions=("a", "10")),
-            ],
-            tuple(range(10)),
-            (RangeExpression(start="0", end="a", step="1"), RangeExpression(start="0", end="10", step="1")),
-            id="range(a): success case",
-        ),
-        pytest.param(
-            [
-                NameObj(value=3, expressions=("a", "3")),
-                ConstantObj(value=10, expressions=("10",)),
-            ],
-            tuple(range(3, 10)),
-            (RangeExpression(start="a", end="10", step="1"), RangeExpression(start="3", end="10", step="1")),
-            id="range(a, 10): success case",
-        ),
-        pytest.param(
-            [
-                NameObj(value=3, expressions=("a", "3")),
-                ConstantObj(value=10, expressions=("10",)),
-                ConstantObj(value=2, expressions=("2",)),
-            ],
-            tuple(range(3, 10, 2)),
-            (RangeExpression(start="a", end="10", step="2"), RangeExpression(start="3", end="10", step="2")),
-            id="range(a, 10, 2): success case",
-        ),
-    ],
-)
-def test_range_parse(expressions: list[ExprObj], expected_iter, expected_expressions):
-    result_iter, result_expressions = CallExpr._range_parse(expressions)
-
-    assert result_iter == expected_iter
-    assert result_expressions == expected_expressions
-
-
-@pytest.mark.parametrize(
-    "args, expected",
-    [
-        pytest.param(["10"], RangeExpression(start="0", end="10", step="1"), id="range(10): success case"),
-        pytest.param(["a", "10"], RangeExpression(start="a", end="10", step="1"), id="range(a, 10): success case"),
-        pytest.param(
-            ["a", "10", "2"], RangeExpression(start="a", end="10", step="2"), id="range(a, 10, 2): success case"
-        ),
-        pytest.param(
-            ["1", "10", "2"], RangeExpression(start="1", end="10", step="2"), id="range(1, 10, 2): success case"
-        ),
-    ],
-)
-def test_create_range_dict(args: list, expected):
-    result = CallExpr._create_range_expression(args)
-
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    "arg_value_list, expected",
-    [
-        pytest.param([10], range(10), id="range(10): success case"),
-        pytest.param([3, 10], range(3, 10), id="range(3, 10): success case"),
-        pytest.param([2, 10, 2], range(2, 10, 2), id="range(2, 10, 2): success case"),
-    ],
-)
-def test_create_range_iter(arg_value_list: list, expected):
-    result = CallExpr._create_range_iter(arg_value_list)
-    assert result == expected
+def test_attribute_call_parse(attr_obj: AttributeObj, args: list[ExprObj], keyword_arg_dict: dict):
+    pass

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_call_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_call_expr.py
@@ -1,48 +1,95 @@
 import pytest
 
-from app.visualize.analysis.stmt.parser.expr.models.expr_obj import AttributeObj, ExprObj
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import (
+    AttributeObj,
+    ExprObj,
+    ConstantObj,
+    PrintObj,
+    RangeObj,
+)
+from app.visualize.analysis.stmt.parser.expr.models.range_expression import RangeExpression
+from app.visualize.analysis.stmt.parser.expr.parser.built_in_func.print_expr import PrintExpr
+from app.visualize.analysis.stmt.parser.expr.parser.built_in_func.range_expr import RangeExpr
+from app.visualize.analysis.stmt.parser.expr.parser.call_expr import CallExpr
 
 
 @pytest.mark.parametrize(
     "func_name, args, keyword_arg_dict, expected",
     [
         pytest.param(
+            "print",
+            [ConstantObj(value="Hello, World!", expressions=("Hello, World!",))],
+            {},
+            PrintObj(value="Hello, World!", expressions=("Hello, World!",)),
             id="Built-in-function print: success case",
         ),
         pytest.param(
+            "range",
+            [ConstantObj(value=5, expressions=("5",))],
+            {},
+            RangeObj(value=tuple(range(0, 5, 1)), expressions=(RangeExpression(start="0", end="5", step="1"),)),
             id="Built-in-function range: success case",
-        ),
-        pytest.param(
-            id="attribute-function append: success case",
         ),
     ],
 )
-def test_parse(func_name: str | AttributeObj, args: list[ExprObj], keyword_arg_dict: dict):
-    pass
+def test_built_in_parse(mocker, func_name: str | AttributeObj, args: list[ExprObj], keyword_arg_dict: dict, expected):
+    mock_built_in_call_parse = mocker.patch.object(CallExpr, "_built_in_call_parse", return_value=expected)
+
+    result = CallExpr.parse(func_name, args, keyword_arg_dict)
+
+    assert result == expected
+    assert mock_built_in_call_parse.called_once_with(func_name, args, keyword_arg_dict)
 
 
 @pytest.mark.parametrize(
     "func_name, args, keyword_arg_dict, expected",
     [
         pytest.param(
+            "print",
+            [ConstantObj(value="Hello, World!", expressions=("Hello, World!",))],
+            {},
+            PrintObj(value="Hello, World!", expressions=("Hello, World!",)),
             id="Built-in-function print: success case",
         ),
+    ],
+)
+def test_built_in_print_call_parse(mocker, func_name: str, args: list[ExprObj], keyword_arg_dict: dict, expected):
+    mock_print_expr_class = mocker.patch.object(PrintExpr, "parse", return_value=expected)
+
+    result = CallExpr._built_in_call_parse(func_name, args, keyword_arg_dict)
+
+    assert result == expected
+    assert mock_print_expr_class.called_once_with(args, keyword_arg_dict)
+
+
+@pytest.mark.parametrize(
+    "func_name, args, keyword_arg_dict, expected",
+    [
         pytest.param(
+            "range",
+            [ConstantObj(value=5, expressions=("5",))],
+            {},
+            RangeObj(value=tuple(range(0, 5, 1)), expressions=(RangeExpression(start="0", end="5", step="1"),)),
             id="Built-in-function range: success case",
         ),
     ],
 )
-def test_built_in_call_parse(func_name: str, args: list[ExprObj], keyword_arg_dict: dict):
-    pass
+def test_built_in_range_call_parse(mocker, func_name: str, args: list[ExprObj], keyword_arg_dict: dict, expected):
+    mock_range_expr_class = mocker.patch.object(RangeExpr, "parse", return_value=expected)
+
+    result = CallExpr._built_in_call_parse(func_name, args, keyword_arg_dict)
+
+    assert result == expected
+    assert mock_range_expr_class.called_once_with(args)
 
 
-@pytest.mark.parametrize(
-    "attr_obj, args, keyword_arg_dict, expected",
-    [
-        pytest.param(
-            id="attribute-function append: success case",
-        ),
-    ],
-)
-def test_attribute_call_parse(attr_obj: AttributeObj, args: list[ExprObj], keyword_arg_dict: dict):
-    pass
+# @pytest.mark.parametrize(
+#     "attr_obj, args, keyword_arg_dict, expected",
+#     [
+#         pytest.param(
+#             id="attribute-function append: success case",
+#         ),
+#     ],
+# )
+# def test_attribute_call_parse(attr_obj: AttributeObj, args: list[ExprObj], keyword_arg_dict: dict, expected):
+#     pass

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_list_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_list_expr.py
@@ -58,17 +58,17 @@ def test_get_value(mocker, value):
 @pytest.mark.parametrize(
     "expressions, transposed_expression_lists_result, expected",
     [
-        pytest.param([("10",), ("20",)], [("10", "20")], ("[10,20]",), id="[10, 20]: success case"),
+        pytest.param([("10",), ("20",)], [("10", "20")], ("[10, 20]",), id="[10, 20]: success case"),
         pytest.param(
             [("a", "10"), ("20",), ("30",)],
             [("a", "20", "30"), ("10", "20", "30")],
-            ("[a,20,30]", "[10,20,30]"),
+            ("[a, 20, 30]", "[10, 20, 30]"),
             id="[a, 20, 30]: success case",
         ),
         pytest.param(
             [("a + 1", "10 + 1", "11"), ("20",)],
             [("a + 1", "20"), ("10 + 1", "20"), ("11", "20")],
-            ("[a + 1,20]", "[10 + 1,20]", "[11,20]"),
+            ("[a + 1, 20]", "[10 + 1, 20]", "[11, 20]"),
             id="[a + 1, 20]: success case",
         ),
     ],

--- a/tests/visualize/generator/converter/test_assign_converter.py
+++ b/tests/visualize/generator/converter/test_assign_converter.py
@@ -28,7 +28,7 @@ def create_assign():
             3,
             ["3"],
             "constant",
-            AssignViz(variables=[Variable(id=1, name="a", expr="3", highlights=[0], depth=1, type="variable")]),
+            AssignViz(variables=[Variable(id=1, name="a", expr="3", type="variable")]),
             id="a = 3: success case",
         ),
         pytest.param(
@@ -36,7 +36,7 @@ def create_assign():
             4,
             ["a + 1", "3 + 1", "4"],
             "binop",
-            AssignViz(variables=[Variable(id=1, name="b", expr="4", highlights=[0], depth=1, type="variable")]),
+            AssignViz(variables=[Variable(id=1, name="b", expr="4", type="variable")]),
             id="b = a + 1: success case",
         ),
         pytest.param(
@@ -46,8 +46,8 @@ def create_assign():
             "binop",
             AssignViz(
                 variables=[
-                    Variable(id=1, name="c", expr="5", highlights=[0], depth=1, type="variable"),
-                    Variable(id=1, name="d", expr="5", highlights=[0], depth=1, type="variable"),
+                    Variable(id=1, name="c", expr="5", type="variable"),
+                    Variable(id=1, name="d", expr="5", type="variable"),
                 ],
             ),
             id="c, d = b + 1: success case",
@@ -58,7 +58,7 @@ def create_assign():
             ["[1,2,3]"],
             "list",
             AssignViz(
-                variables=[Variable(id=1, name="e", expr="[1,2,3]", highlights=[0, 1, 2], depth=1, type="list")],
+                variables=[Variable(id=1, name="e", expr="[1,2,3]", type="list")],
             ),
             id="e = [1, 2, 3]: success case",
         ),
@@ -68,7 +68,7 @@ def create_assign():
             ["['Hello','World']"],
             "list",
             AssignViz(
-                variables=[Variable(id=1, name="f", expr="['Hello','World']", highlights=[0, 1], depth=1, type="list")],
+                variables=[Variable(id=1, name="f", expr="['Hello','World']", type="list")],
             ),
             id="f = ['Hello', 'World']: success case",
         ),
@@ -78,16 +78,13 @@ def create_assign():
             ["[a + 1,b]", "[10 + 1,10]", "[11,10]"],
             "list",
             AssignViz(
-                variables=[Variable(id=1, name="g", expr="[11,10]", highlights=[0, 1], depth=1, type="list")],
+                variables=[Variable(id=1, name="g", expr="[11,10]", type="list")],
             ),
             id="g = [a + 1, b]: success case",
         ),
     ],
 )
 def test_convert(create_assign, targets, value, expressions, var_type, expected):
-    viz_manager = VisualizationManager()
-    viz_manager.get_depth = MagicMock(return_value=1)
-
-    result = AssignConverter.convert(create_assign(targets, value, expressions, var_type), viz_manager)
+    result = AssignConverter.convert(create_assign(targets, value, expressions, var_type))
 
     assert result == expected


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #156 
- close #157
- close #158 

## 📝 작업 내용

- append 함수를 추가하면서 ast.attribute가 추가되었습니다. ast.attribute에 대한 내용은 아래 링크 달아놓겠습니다.
- callExpr 함수를 built-in-func과 attribute-func으로 분할했습니다. 
- AssignViz에서 depth와 highlight를 삭제했습니다. -> 변수를 보여줄 때 글자에 highlight처리하지 않고 배경에 highlight 처리
- ExprViz에 들어가는 highlight를 삭제했습니다 -> 동일하게 값을 만들어줄 때 글자에 highlight처리하지 않고 배경에 highlight 처리
- 안쓰고 있는 import 정리


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- [ast.attribute 정리](https://www.notion.so/ast-Attribute-2b9de3209dfc4c3e942f0b825b51c0b9)
- append 함수를 추가하면서 call함수에 큰 변화가 있었습니다. 더 좋은 방식이 있으면 제안해주세요
