### PR TITLE
[#172]bug: If, else 표현식(expr)의 하이라이트가 모든 인덱스가 받아짐 

### DIFF
--- a/app/visualize/generator/converter/expr_converter.py
+++ b/app/visualize/generator/converter/expr_converter.py
@@ -50,7 +50,7 @@ class ExprConverter:
 
     @staticmethod
     def _convert_to_print_viz(expr_stmt_obj: ExprStmtObj, call_id, depth):
-        highlights = ExprHighlight.get_highlight_indexes(expr_stmt_obj.expressions)
+        highlights = ExprHighlight.get_highlight_indexes_exclusive_last(expr_stmt_obj.expressions)
 
         print_vizs = [
             PrintViz(

--- a/app/visualize/generator/highlight/expr_highlight.py
+++ b/app/visualize/generator/highlight/expr_highlight.py
@@ -1,7 +1,7 @@
 class ExprHighlight:
 
     @staticmethod
-    def get_highlight_indexes(parsed_exprs):
+    def get_highlight_indexes_exclusive_last(parsed_exprs):
         highlights = []
         pre_expr = parsed_exprs[0]
 
@@ -13,6 +13,19 @@ class ExprHighlight:
 
         # 마지막 요소는 전체 인덱스 반환
         highlights.append(list(range(len(parsed_exprs[-1]))))
+
+        return highlights
+
+    @staticmethod
+    def get_highlight_indexes(parsed_exprs):
+        highlights = []
+        pre_expr = parsed_exprs[0]
+
+        highlights.append(list(range(len(parsed_exprs[0]))))
+
+        for cur_expr in parsed_exprs[1:]:
+            highlights.append(ExprHighlight._immediate_expression_indices(pre_expr, cur_expr))
+            pre_expr = cur_expr
 
         return highlights
 

--- a/tests/visualize/generator/highlight/test_expr_highlight.py
+++ b/tests/visualize/generator/highlight/test_expr_highlight.py
@@ -20,6 +20,6 @@ from app.visualize.generator.highlight.expr_highlight import ExprHighlight
     ],
 )
 def test_get_highlight_attr(parsed_exprs, expected):
-    result = ExprHighlight.get_highlight_indexes(parsed_exprs)
+    result = ExprHighlight.get_highlight_indexes_exclusive_last(parsed_exprs)
 
     assert result == expected


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #172 

## 📝 작업 내용

- 오류 원인은 **마지막 배열은 무조건 전체 인덱스를 반환했기 때문**이었습니다. If문 조건절의 최종값은 True, False로 따로 처치를 해서 마지막 값이 아닌데도 전체 인덱스가 반환되었습니다.
- 그래서 기존 하이라이트 추출 함수를  get_highlight_indexes -> **get_highlight_indexes_exclusive_last**로 변경하고, 새로운  get_highlight_indexes 함수를 추가했습니다.

![image](https://github.com/user-attachments/assets/405ac1a3-11b5-47d2-86eb-15a55917303f)

- 근데 새로운 문제를 발견해습니다.
    -  "10 * 10 < 99" -> "100 < 99" 일 때 100의 인덱스인 [0, 1]를 리턴해야 하는데 전체 인덱스를 리턴하고 있습니다. 수정하려고 했지만, 바뀐 부분을 어떻게 찾아야 될지 몰라서 수정 못했습니다..
    


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


