### PR TITLE
[#194]fix: ExprStmt에 type을 바꾸는 과정에서 expr로 고정되는 문제

### DIFF
--- a/app/visualize/analysis/stmt/parser/assign_stmt.py
+++ b/app/visualize/analysis/stmt/parser/assign_stmt.py
@@ -39,6 +39,9 @@ class AssignStmt:
             elif isinstance(target_node, ast.List):
                 expr_obj = ExprTraveler.travel(target_node, elem_container)
 
+            elif isinstance(target_node, ast.Subscript):
+                expr_obj = ExprTraveler.travel(target_node, elem_container)
+
             else:
                 raise TypeError(f"[AssignParser]: {type(target_node)}는 잘못된 타입입니다.")
 

--- a/app/visualize/generator/converter/expr_converter.py
+++ b/app/visualize/generator/converter/expr_converter.py
@@ -41,6 +41,7 @@ class ExprConverter:
                 id=call_id,
                 depth=depth,
                 expr=expr_stmt_obj.expressions[idx],
+                type=expr_stmt_obj.expr_type.value,
             )
             for idx in range(len(expr_stmt_obj.expressions))
         ]

--- a/app/visualize/generator/models/expr_viz.py
+++ b/app/visualize/generator/models/expr_viz.py
@@ -8,4 +8,4 @@ class ExprViz:
     id: int
     depth: int
     expr: ExprType
-    type: str = field(default="expr", init=False)
+    type: str


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #194 

## 📝 작업 내용

- ExprViz(id=3, depth=1, expr='10', type='expr') -> ExprViz(id=3, depth=1, expr='10', type='variable') 

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- 