### PR TITLE
[#190]fix: 빈 리스트일 때 expressions 오류 해결

### DIFF
--- a/app/visualize/analysis/stmt/parser/expr/parser/list_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/list_expr.py
@@ -19,6 +19,10 @@ class ListExpr:
     def _concat_expressions(elts: list[ExprObj]):
         elts_expression_lists = [elt.expressions for elt in elts]
 
+        # 0개의 원소를 가진 리스트인 경우
+        if not elts:
+            return ("[]",)
+
         # [("a + 1", "10 + 1", "11"), ("20",)] -> [("a + 1", "20"), ("10 + 1", "20"), ("11", "20")]
         transposed_expression_lists = utils.transpose_with_last_fill(elts_expression_lists)
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #190 

## 📝 작업 내용

- 빈 리스트인 경우 표현식 만드는 과정에서 발생한 에러 해결

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
