### PR TITLE
[#205]feat: 라인 수 에 해당되는 코드를 모든 Viz 데이터에 추가

### DIFF
--- a/app/visualize/code_visualizer.py
+++ b/app/visualize/code_visualizer.py
@@ -1,7 +1,7 @@
 import ast
 
-from app.visualize.container.element_container import ElementContainer
 from app.visualize.analysis.stmt.stmt_traveler import StmtTraveler
+from app.visualize.container.element_container import ElementContainer
 from app.visualize.generator.converter_traveler import ConverterTraveler
 from app.visualize.generator.visualization_manager import VisualizationManager
 
@@ -12,7 +12,7 @@ class CodeVisualizer:
     def __init__(self, source_code: str):
         self._parsed_node = ast.parse(source_code)
         self._elem_container = ElementContainer()
-        self._visualization_manager = VisualizationManager()
+        self._visualization_manager = VisualizationManager(source_code)
 
     def visualize_code(self):
         analyzed_stmt_list = self.get_analyzed_stmt_nodes()

--- a/app/visualize/generator/converter/assign_converter.py
+++ b/app/visualize/generator/converter/assign_converter.py
@@ -1,28 +1,29 @@
 from app.visualize.analysis.stmt.models.assign_stmt_obj import AssignStmtObj
 from app.visualize.generator.models.assign_viz import AssignViz
 from app.visualize.generator.models.variable_vlz import Variable
+from app.visualize.generator.visualization_manager import VisualizationManager
 from app.visualize.utils import utils
 
 
 class AssignConverter:
     @staticmethod
-    def convert(assign_obj: AssignStmtObj):
+    def convert(assign_obj: AssignStmtObj, viz_manager: VisualizationManager):
         expr_stmt_obj = assign_obj.expr_stmt_obj
         var_type = expr_stmt_obj.expr_type.value
 
-        return AssignConverter._convert_to_assign_viz(expr_stmt_obj, assign_obj.targets, var_type)
+        return AssignConverter._convert_to_assign_viz(expr_stmt_obj, viz_manager, assign_obj.targets, var_type)
 
     @staticmethod
-    def _convert_to_assign_viz(expr_stmt_obj, targets, var_type: str):
+    def _convert_to_assign_viz(expr_stmt_obj, viz_manager, targets, var_type: str):
         variable_list = []
 
         for target in targets:
-            AssignConverter._create_variable_list(expr_stmt_obj, target, var_type, variable_list)
+            AssignConverter._create_variable_list(expr_stmt_obj, viz_manager, target, var_type, variable_list)
 
         return AssignViz(variables=variable_list)
 
     @staticmethod
-    def _create_variable_list(expr_stmt_obj, target, var_type: str, variable_list):
+    def _create_variable_list(expr_stmt_obj, viz_manager, target, var_type: str, variable_list):
 
         # target이 list나 tuple일 경우
         if utils.is_array(target):
@@ -40,6 +41,7 @@ class AssignConverter:
                         id=expr_stmt_obj.id,
                         expr=str(expr_stmt_obj.value[idx]),
                         name=target[idx],
+                        code=viz_manager.get_code_by_idx(expr_stmt_obj.id),
                         type="variable",
                     )
                     for idx in range(len(target))
@@ -52,6 +54,7 @@ class AssignConverter:
                     id=expr_stmt_obj.id,
                     expr=expr_stmt_obj.expressions[-1],
                     name=target,
+                    code=viz_manager.get_code_by_idx(expr_stmt_obj.id),
                     type=var_type,
                 )
             )

--- a/app/visualize/generator/converter/expr_converter.py
+++ b/app/visualize/generator/converter/expr_converter.py
@@ -17,31 +17,32 @@ class ExprConverter:
         var_type = expr_stmt_obj.expr_type
 
         if var_type is ExprType.VARIABLE:
-            return ExprConverter._convert_to_expr_viz(expr_stmt_obj, call_id, depth)
+            return ExprConverter._convert_to_expr_viz(expr_stmt_obj, viz_manager, call_id, depth)
 
         elif var_type is ExprType.LIST:
-            return ExprConverter._convert_to_expr_viz(expr_stmt_obj, call_id, depth)
+            return ExprConverter._convert_to_expr_viz(expr_stmt_obj, viz_manager, call_id, depth)
 
         elif var_type is ExprType.TUPLE:
-            return ExprConverter._convert_to_expr_viz(expr_stmt_obj, call_id, depth)
+            return ExprConverter._convert_to_expr_viz(expr_stmt_obj, viz_manager, call_id, depth)
 
         elif var_type is ExprType.PRINT:
-            return ExprConverter._convert_to_print_viz(expr_stmt_obj, call_id, depth)
+            return ExprConverter._convert_to_print_viz(expr_stmt_obj, viz_manager, call_id, depth)
 
         elif var_type is ExprType.APPEND:
-            return ExprConverter._convert_to_append_viz(expr_stmt_obj, call_id, depth)
+            return ExprConverter._convert_to_append_viz(expr_stmt_obj, viz_manager, call_id, depth)
 
         else:
             raise TypeError(f"[ExprConverter]:{var_type}는 지원하지 않습니다.")
 
     @staticmethod
-    def _convert_to_expr_viz(expr_stmt_obj: ExprStmtObj, call_id, depth):
+    def _convert_to_expr_viz(expr_stmt_obj: ExprStmtObj, viz_manager: VisualizationManager, call_id, depth):
         expr_vizs = [
             ExprViz(
                 id=call_id,
                 depth=depth,
                 expr=expr_stmt_obj.expressions[idx],
                 type=expr_stmt_obj.expr_type.value,
+                code=viz_manager.get_code_by_idx(call_id),
             )
             for idx in range(len(expr_stmt_obj.expressions))
         ]
@@ -49,7 +50,7 @@ class ExprConverter:
         return expr_vizs
 
     @staticmethod
-    def _convert_to_print_viz(expr_stmt_obj: ExprStmtObj, call_id, depth):
+    def _convert_to_print_viz(expr_stmt_obj: ExprStmtObj, viz_manager: VisualizationManager, call_id, depth):
         highlights = ExprHighlight.get_highlight_indexes_exclusive_last(expr_stmt_obj.expressions)
 
         print_vizs = [
@@ -59,6 +60,7 @@ class ExprConverter:
                 expr=expr_stmt_obj.expressions[idx],
                 highlights=highlights[idx],
                 console=expr_stmt_obj.value if idx == len(expr_stmt_obj.expressions) - 1 else None,
+                code=viz_manager.get_code_by_idx(call_id),
             )
             for idx in range(len(expr_stmt_obj.expressions))
         ]
@@ -66,7 +68,7 @@ class ExprConverter:
         return print_vizs
 
     @staticmethod
-    def _convert_to_append_viz(expr_stmt_obj: ExprStmtObj, call_id, depth):
+    def _convert_to_append_viz(expr_stmt_obj: ExprStmtObj, viz_manager: VisualizationManager, call_id, depth):
         append_vizs = []
         expr_vizs = ExprConverter._convert_to_expr_viz(expr_stmt_obj, call_id, depth)
         append_vizs.extend(expr_vizs)

--- a/app/visualize/generator/converter/flow_control_converter.py
+++ b/app/visualize/generator/converter/flow_control_converter.py
@@ -14,4 +14,5 @@ class FlowControlConverter:
             depth=viz_manager.get_depth(),
             expr=node.flow_control_type.value,
             highlights=list(range(len(node.flow_control_type.value))),
+            code=viz_manager.get_code_by_idx(node.id),
         )

--- a/app/visualize/generator/converter/for_header_converter.py
+++ b/app/visualize/generator/converter/for_header_converter.py
@@ -1,6 +1,6 @@
 # for_stmt_obj를 받아서 for_viz를 반환하는 클래스
-from app.visualize.analysis.stmt.parser.expr.models.expr_obj import RangeObj
 from app.visualize.analysis.stmt.models.for_stmt_obj import ForStmtObj
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import RangeObj
 from app.visualize.generator.highlight.for_highlight import ForHighlight
 from app.visualize.generator.models.for_viz import ForViz, ForConditionViz
 from app.visualize.generator.visualization_manager import VisualizationManager
@@ -29,7 +29,13 @@ class ForHeaderConvertor:
         condition = ForHeaderConvertor._get_condition(target_name, iter_obj)
         highlight = ForHighlight.get_highlight_attr(condition)
 
-        return ForViz(id=call_id, depth=depth, condition=condition, highlights=highlight)
+        return ForViz(
+            id=call_id,
+            depth=depth,
+            condition=condition,
+            highlights=highlight,
+            code=viz_manager.get_code_by_idx(call_id),
+        )
 
     @staticmethod
     def _get_condition(target_name: str, iter_obj: RangeObj):

--- a/app/visualize/generator/converter/if_converter.py
+++ b/app/visualize/generator/converter/if_converter.py
@@ -17,14 +17,16 @@ class IfConverter:
             if not isinstance(condition, ConditionObj):
                 raise TypeError(f"[IfConverter]: 지원하지 않는 조건문 타입입니다.: {type(condition)}")
 
-            if_header_conditions.append(IfConverter._create__if_else_define_viz(condition))
+            if_header_conditions.append(IfConverter._create__if_else_define_viz(condition, viz_manager))
 
         return IfElseDefineViz(depth=viz_manager.get_depth(), conditions=tuple(if_header_conditions))
 
     @staticmethod
-    def _create__if_else_define_viz(condition: ConditionObj) -> ConditionViz:
+    def _create__if_else_define_viz(condition: ConditionObj, viz_manager: VisualizationManager) -> ConditionViz:
         expr = condition.expressions[0] if condition.type != "else" else ""
-        return ConditionViz(id=condition.id, expr=expr, type=condition.type.value)
+        return ConditionViz(
+            id=condition.id, expr=expr, type=condition.type.value, code=viz_manager.get_code_by_idx(condition.id)
+        )
 
     @staticmethod
     def convert_to_if_else_change_viz(

--- a/app/visualize/generator/converter/while_converter.py
+++ b/app/visualize/generator/converter/while_converter.py
@@ -1,19 +1,21 @@
 from app.visualize.analysis.stmt.models.while_stmt_obj import WhileStmtObj
 from app.visualize.generator.models.while_viz import WhileDefineViz, WhileChangeConditionViz
+from app.visualize.generator.visualization_manager import VisualizationManager
 
 
 class WhileConverter:
 
     @staticmethod
-    def convert_to_while_define_viz(while_obj: WhileStmtObj, depth):
+    def convert_to_while_define_viz(while_obj: WhileStmtObj, viz_manager: VisualizationManager, depth):
         return WhileDefineViz(
             id=while_obj.id,
             expr=while_obj.while_cycles[0].condition_exprs[0],
             depth=depth,
+            code=viz_manager.get_code_by_idx(while_obj.id),
         )
 
     @staticmethod
-    def convert_to_while_change_condition_viz(call_id, while_cycle, depth):
+    def convert_to_while_change_condition_viz(call_id, viz_manager: VisualizationManager, while_cycle, depth):
         change_condition_steps = []
 
         for idx in range(len(while_cycle.condition_exprs)):
@@ -22,6 +24,7 @@ class WhileConverter:
                     id=call_id,
                     depth=depth,
                     expr=while_cycle.condition_exprs[idx],
+                    code=viz_manager.get_code_by_idx(call_id),
                 )
             )
 

--- a/app/visualize/generator/converter_traveler.py
+++ b/app/visualize/generator/converter_traveler.py
@@ -46,7 +46,7 @@ class ConverterTraveler:
     def _convert_to_assign_vizs(assign_obj: AssignStmtObj, viz_manager: VisualizationManager):
         steps = []
         steps.extend(ConverterTraveler._convert_to_expr_vizs(assign_obj.expr_stmt_obj, viz_manager))
-        steps.append(AssignConverter.convert(assign_obj))
+        steps.append(AssignConverter.convert(assign_obj, viz_manager))
 
         return steps
 

--- a/app/visualize/generator/converter_traveler.py
+++ b/app/visualize/generator/converter_traveler.py
@@ -101,11 +101,13 @@ class ConverterTraveler:
         steps = []
         depth = viz_manager.get_depth()
 
-        while_define_viz = WhileConverter.convert_to_while_define_viz(while_obj, depth)
+        while_define_viz = WhileConverter.convert_to_while_define_viz(while_obj, viz_manager, depth)
 
         for while_cycle in while_obj.while_cycles:
             steps.append(while_define_viz)
-            steps.extend(WhileConverter.convert_to_while_change_condition_viz(while_obj.id, while_cycle, depth))
+            steps.extend(
+                WhileConverter.convert_to_while_change_condition_viz(while_obj.id, viz_manager, while_cycle, depth)
+            )
             steps.extend(ConverterTraveler.travel(while_cycle.body_objs, viz_manager))
 
         return steps

--- a/app/visualize/generator/models/expr_viz.py
+++ b/app/visualize/generator/models/expr_viz.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from app.visualize.analysis.stmt.parser.expr.models.expr_type import ExprType
 
@@ -8,4 +8,5 @@ class ExprViz:
     id: int
     depth: int
     expr: ExprType
+    code: str
     type: str

--- a/app/visualize/generator/models/flow_control_viz.py
+++ b/app/visualize/generator/models/flow_control_viz.py
@@ -7,4 +7,5 @@ class FlowControlViz:
     depth: int
     expr: str
     highlights: []
+    code: str
     type: str = field(default="flowControl", init=False)

--- a/app/visualize/generator/models/for_viz.py
+++ b/app/visualize/generator/models/for_viz.py
@@ -25,10 +25,11 @@ class ForViz:
     depth: int
     condition: ForConditionViz
     highlights: []
+    code: str
     type: str = field(default="for", init=False)
 
     def update(self, new_condition, highlights):
-        return ForViz(self.id, self.depth, new_condition, highlights)
+        return ForViz(self.id, self.depth, new_condition, highlights, self.code)
 
 
 """

--- a/app/visualize/generator/models/if_viz.py
+++ b/app/visualize/generator/models/if_viz.py
@@ -6,6 +6,7 @@ class ConditionViz:
     id: int
     expr: str
     type: str
+    code: str
 
 
 @dataclass(frozen=True)

--- a/app/visualize/generator/models/print_viz.py
+++ b/app/visualize/generator/models/print_viz.py
@@ -10,12 +10,3 @@ class PrintViz:
     console: str | None
     code: str
     type: str = field(default="print", init=False)
-
-
-"""
-    @ id: 식별값
-    @ depth: 깊이
-    @ name: 변수 이름
-    @ value: 변수 값
-
-"""

--- a/app/visualize/generator/models/print_viz.py
+++ b/app/visualize/generator/models/print_viz.py
@@ -8,6 +8,7 @@ class PrintViz:
     expr: str
     highlights: []
     console: str | None
+    code: str
     type: str = field(default="print", init=False)
 
 

--- a/app/visualize/generator/models/variable_vlz.py
+++ b/app/visualize/generator/models/variable_vlz.py
@@ -6,6 +6,7 @@ class Variable:
     id: int
     expr: str
     name: str
+    code: str
     type: str
 
 

--- a/app/visualize/generator/models/variable_vlz.py
+++ b/app/visualize/generator/models/variable_vlz.py
@@ -8,10 +8,3 @@ class Variable:
     name: str
     code: str
     type: str
-
-
-"""
-    @ depth: 깊이
-    @ expr: 변수에 들어갈 표현식
-    @ name: 변수 이름
-"""

--- a/app/visualize/generator/models/while_viz.py
+++ b/app/visualize/generator/models/while_viz.py
@@ -6,6 +6,7 @@ class WhileDefineViz:
     id: int
     expr: str
     depth: int
+    code: str
     type: str = "whileDefine"
 
 
@@ -14,4 +15,5 @@ class WhileChangeConditionViz:
     id: int
     depth: int
     expr: str
+    code: str
     type: str = "whileChangeCondition"

--- a/app/visualize/generator/visualization_manager.py
+++ b/app/visualize/generator/visualization_manager.py
@@ -32,5 +32,9 @@ class VisualizationManager:
         return self.depth
 
     def get_code_by_idx(self, idx):
-        # idx에 해당하는 코드 라인 리턴
-        return self.processed_lines[idx - 1]
+        try:
+            if self.processed_lines[idx - 1] is None:
+                return ""
+            return self.processed_lines[idx - 1]
+        except IndexError:
+            return ""

--- a/app/visualize/generator/visualization_manager.py
+++ b/app/visualize/generator/visualization_manager.py
@@ -33,4 +33,4 @@ class VisualizationManager:
 
     def get_code_by_idx(self, idx):
         # idx에 해당하는 코드 라인 리턴
-        return self.processed_lines.pop(idx - 1)
+        return self.processed_lines[idx - 1]

--- a/app/visualize/generator/visualization_manager.py
+++ b/app/visualize/generator/visualization_manager.py
@@ -1,6 +1,24 @@
 class VisualizationManager:
-    def __init__(self):
+    def __init__(self, source_code=""):
+        self.source_code = source_code
+        self.processed_lines = self.process_code()
         self.depth = 1
+
+    def process_code(self):
+        # 줄 단위로 분리
+        lines = self.source_code.split("\n")
+        processed_lines = []
+
+        for line in lines:
+            # 줄의 시작 부분에서 공백 제거 (들여쓰기 제거)
+            stripped_line = line.lstrip()
+            # 공백이 아닌 내용이 있는 경우만 추가
+            if stripped_line:
+                processed_lines.append(stripped_line)
+            else:
+                processed_lines.append(None)
+
+        return processed_lines
 
     def increase_depth(self):
         self.depth = self.depth + 1
@@ -12,3 +30,7 @@ class VisualizationManager:
     def decrease_depth(self):
         self.depth = self.depth - 1
         return self.depth
+
+    def get_code_by_idx(self, idx):
+        # idx에 해당하는 코드 라인 리턴
+        return self.processed_lines.pop(idx - 1)

--- a/tests/visualize/generator/converter/test_assign_converter.py
+++ b/tests/visualize/generator/converter/test_assign_converter.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 
 from app.visualize.analysis.stmt.models.assign_stmt_obj import AssignStmtObj
@@ -8,6 +6,7 @@ from app.visualize.analysis.stmt.parser.expr.models.expr_type import ExprType
 from app.visualize.generator.converter.assign_converter import AssignConverter
 from app.visualize.generator.models.assign_viz import AssignViz
 from app.visualize.generator.models.variable_vlz import Variable
+from app.visualize.generator.visualization_manager import VisualizationManager
 
 
 @pytest.fixture()
@@ -28,7 +27,7 @@ def create_assign():
             3,
             ["3"],
             ExprType.VARIABLE,
-            AssignViz(variables=[Variable(id=1, name="a", expr="3", type="variable")]),
+            AssignViz(variables=[Variable(id=1, name="a", expr="3", type="variable", code="")]),
             id="a = 3: success case",
         ),
         pytest.param(
@@ -36,7 +35,7 @@ def create_assign():
             4,
             ["a + 1", "3 + 1", "4"],
             ExprType.VARIABLE,
-            AssignViz(variables=[Variable(id=1, name="b", expr="4", type="variable")]),
+            AssignViz(variables=[Variable(id=1, name="b", expr="4", type="variable", code="")]),
             id="b = a + 1: success case",
         ),
         pytest.param(
@@ -46,8 +45,8 @@ def create_assign():
             ExprType.VARIABLE,
             AssignViz(
                 variables=[
-                    Variable(id=1, name="c", expr="5", type="variable"),
-                    Variable(id=1, name="d", expr="5", type="variable"),
+                    Variable(id=1, name="c", expr="5", type="variable", code=""),
+                    Variable(id=1, name="d", expr="5", type="variable", code=""),
                 ],
             ),
             id="c, d = b + 1: success case",
@@ -58,7 +57,7 @@ def create_assign():
             ["[1,2,3]"],
             ExprType.LIST,
             AssignViz(
-                variables=[Variable(id=1, name="e", expr="[1,2,3]", type="list")],
+                variables=[Variable(id=1, name="e", expr="[1,2,3]", type="list", code="")],
             ),
             id="e = [1, 2, 3]: success case",
         ),
@@ -68,7 +67,7 @@ def create_assign():
             ["['Hello','World']"],
             ExprType.LIST,
             AssignViz(
-                variables=[Variable(id=1, name="f", expr="['Hello','World']", type="list")],
+                variables=[Variable(id=1, name="f", expr="['Hello','World']", type="list", code="")],
             ),
             id="f = ['Hello', 'World']: success case",
         ),
@@ -78,13 +77,13 @@ def create_assign():
             ["[a + 1,b]", "[10 + 1,10]", "[11,10]"],
             ExprType.LIST,
             AssignViz(
-                variables=[Variable(id=1, name="g", expr="[11,10]", type="list")],
+                variables=[Variable(id=1, name="g", expr="[11,10]", type="list", code="")],
             ),
             id="g = [a + 1, b]: success case",
         ),
     ],
 )
 def test_convert(create_assign, targets, value, expressions, var_type, expected):
-    result = AssignConverter.convert(create_assign(targets, value, expressions, var_type))
+    result = AssignConverter.convert(create_assign(targets, value, expressions, var_type), VisualizationManager())
 
     assert result == expected

--- a/tests/visualize/generator/converter/test_expr_converter.py
+++ b/tests/visualize/generator/converter/test_expr_converter.py
@@ -4,6 +4,7 @@ from app.visualize.analysis.stmt.models.expr_stmt_obj import ExprStmtObj
 from app.visualize.analysis.stmt.parser.expr.models.expr_type import ExprType
 from app.visualize.generator.converter.expr_converter import ExprConverter
 from app.visualize.generator.models.print_viz import PrintViz
+from app.visualize.generator.visualization_manager import VisualizationManager
 
 
 @pytest.fixture
@@ -31,6 +32,7 @@ def create_print():
                     expr="'*' * (i + 1)\n",
                     highlights=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
                     console=None,
+                    code="'*' * (i + 1)",
                 ),
                 PrintViz(
                     id=1,
@@ -38,6 +40,7 @@ def create_print():
                     expr="'*' * (0 + 1)\n",
                     highlights=[7],
                     console=None,
+                    code="'*' * (i + 1)",
                 ),
                 PrintViz(
                     id=1,
@@ -45,14 +48,17 @@ def create_print():
                     expr="*\n",
                     highlights=[0, 1],
                     console="*\n",
+                    code="'*' * (i + 1)",
                 ),
             ],
             id="'*' * (i + 1): success case",
         )
     ],
 )
-def test_print_convert(create_print, value, expressions, expected):
+def test_print_convert(mocker, create_print, value, expressions, expected):
     print_obj = create_print(value, expressions)
-    result = ExprConverter._convert_to_print_viz(print_obj, 1, 1)
+
+    mocker.patch.object(VisualizationManager, "get_code_by_idx", return_value="'*' * (i + 1)"),
+    result = ExprConverter._convert_to_print_viz(print_obj, VisualizationManager(), 1, 1)
 
     assert result == expected

--- a/tests/visualize/generator/converter/test_flow_control_converter.py
+++ b/tests/visualize/generator/converter/test_flow_control_converter.py
@@ -1,18 +1,19 @@
 import pytest
-from app.visualize.analysis.stmt.models.flow_control_obj import PassStmtObj, BreakStmtObj
 
+from app.visualize.analysis.stmt.models.flow_control_obj import PassStmtObj, BreakStmtObj
 from app.visualize.generator.converter.flow_control_converter import FlowControlConverter
 from app.visualize.generator.models.flow_control_viz import FlowControlViz
+from app.visualize.generator.visualization_manager import VisualizationManager
 
 
 @pytest.mark.parametrize(
     "flow_control_obj, expected",
     [
-        pytest.param(PassStmtObj(id=1), FlowControlViz(1, 1, "pass", [0, 1, 2, 3])),
-        pytest.param(BreakStmtObj(id=1), FlowControlViz(1, 1, "break", [0, 1, 2, 3, 4])),
+        pytest.param(PassStmtObj(id=1), FlowControlViz(1, 1, "pass", [0, 1, 2, 3], code="")),
+        pytest.param(BreakStmtObj(id=1), FlowControlViz(1, 1, "break", [0, 1, 2, 3, 4], code="")),
     ],
 )
-def test_converter(mocker, viz_manager, flow_control_obj: PassStmtObj | BreakStmtObj, expected):
-    actual = FlowControlConverter.convert(flow_control_obj, viz_manager)
+def test_converter(viz_manager, flow_control_obj: PassStmtObj | BreakStmtObj, expected):
+    actual = FlowControlConverter.convert(flow_control_obj, VisualizationManager())
 
     assert actual == expected

--- a/tests/visualize/generator/converter/test_if_converter.py
+++ b/tests/visualize/generator/converter/test_if_converter.py
@@ -47,9 +47,9 @@ from app.visualize.generator.visualization_manager import VisualizationManager
                 ),
             ),
             (
-                ConditionViz(id=1, expr="a > b", type="if"),
-                ConditionViz(id=2, expr="a < b", type="elif"),
-                ConditionViz(id=3, expr="", type="else"),
+                ConditionViz(id=1, expr="a > b", type="if", code=""),
+                ConditionViz(id=2, expr="a < b", type="elif", code=""),
+                ConditionViz(id=3, expr="", type="else", code=""),
             ),
         )
     ],
@@ -85,7 +85,7 @@ def test_convert_to_if_else_define_viz_fail(conditions: tuple[ConditionObj, ...]
 
 
 @pytest.mark.parametrize(
-    "condition, expected",
+    "condition,  expected",
     [
         pytest.param(
             IfConditionObj(
@@ -96,7 +96,7 @@ def test_convert_to_if_else_define_viz_fail(conditions: tuple[ConditionObj, ...]
                 ),
                 result=True,
             ),
-            ConditionViz(id=1, expr="a > b", type="if"),
+            ConditionViz(id=1, expr="a > b", type="if", code=""),
             id="if문 Condition viz 생성",
         ),
         pytest.param(
@@ -108,7 +108,7 @@ def test_convert_to_if_else_define_viz_fail(conditions: tuple[ConditionObj, ...]
                 ),
                 result=False,
             ),
-            ConditionViz(id=1, expr="a < b", type="elif"),
+            ConditionViz(id=1, expr="a < b", type="elif", code=""),
             id="elif문 Condition viz 생성",
         ),
         pytest.param(
@@ -117,13 +117,13 @@ def test_convert_to_if_else_define_viz_fail(conditions: tuple[ConditionObj, ...]
                 expressions=None,
                 result=False,
             ),
-            ConditionViz(id=1, expr="", type="else"),
+            ConditionViz(id=1, expr="", type="else", code=""),
             id="else Condition viz 생성",
         ),
     ],
 )
-def test__create__if_else_define_viz(condition: ConditionObj, expected):
-    actual = IfConverter._create__if_else_define_viz(condition)
+def test__create__if_else_define_viz(mocker, condition: ConditionObj, expected):
+    actual = IfConverter._create__if_else_define_viz(condition, VisualizationManager())
     assert actual == expected
 
 

--- a/tests/visualize/generator/test_converter_traveler.py
+++ b/tests/visualize/generator/test_converter_traveler.py
@@ -1,4 +1,3 @@
-import ast
 from unittest.mock import patch
 
 import pytest
@@ -14,7 +13,7 @@ from app.visualize.generator.visualization_manager import VisualizationManager
 @pytest.fixture
 def get_if_stmt_obj():
     def _get_if_stmt_obj(code):
-        code_analyzer = CodeVisualizer(ast.parse(code))
+        code_analyzer = CodeVisualizer(code)
         return code_analyzer.get_analyzed_stmt_nodes()[0]
 
     return _get_if_stmt_obj

--- a/tests/visualize/generator/test_visualzation_manager.py
+++ b/tests/visualize/generator/test_visualzation_manager.py
@@ -1,0 +1,15 @@
+from app.visualize.generator.visualization_manager import VisualizationManager
+
+
+def test_get_code_by_idx():
+    code = """a = 3
+    for i in range(5):
+        print(i)
+        if i < 2:
+            print(i)
+    """
+    expected = ["a = 3", "for i in range(5):", "print(i)", "if i < 2:", "print(i)"]
+    viz_manager = VisualizationManager(code)
+
+    for i in range(len(expected)):
+        assert viz_manager.get_code_by_idx(i + 1) == expected[i]


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #205 

## 📝 작업 내용

- append_viz, assign_viz를 제외한 나머지 모든 viz에 code 속성을 추가했습니다.
- 모든 Converter에서 viz_manager가 필요해져서 convet 를 호출할 때 viz_manager 인자를 추가했습니다.

### 스크린샷 (선택)
```java

a = 3
for i in range(1):
    print(i)
    if i < 2:
        print(i)

```
![image](https://github.com/user-attachments/assets/af1c9707-374d-4860-b092-04b157a615a0)

## 💬 리뷰 요구사항(선택)

-

