### PR TITLE
[Feat] string fommat 기능 추가

### DIFF
--- a/app/visualize/analysis/stmt/parser/expr/models/expr_obj.py
+++ b/app/visualize/analysis/stmt/parser/expr/models/expr_obj.py
@@ -94,3 +94,10 @@ class AppendObj(AttributeObj):
     value: str
     expressions: tuple[str, ...]
     type: ExprType = field(default=ExprType.APPEND, init=False)
+
+
+@dataclass(frozen=True)
+class FormattedValueObj(ExprObj):
+    value: str
+    expressions: tuple[str, ...]
+    type: ExprType = field(default=ExprType.VARIABLE, init=False)

--- a/app/visualize/analysis/stmt/parser/expr/parser/formatted_value_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/formatted_value_expr.py
@@ -1,0 +1,26 @@
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj, FormattedValueObj
+
+
+class FormattedValueExpr:
+    @staticmethod
+    def parse(expr_obj: ExprObj, conversion, format_spec: ExprObj):
+        value = FormattedValueExpr._get_value(expr_obj, conversion, format_spec)
+        expressions = FormattedValueExpr._concat_expressions(expr_obj, conversion, format_spec)
+
+        return FormattedValueObj(value, expressions)
+
+    @staticmethod
+    def _get_value(expr_obj: ExprObj, conversion, format_spec):
+        return expr_obj.value
+
+    @staticmethod
+    def _concat_expressions(expr_obj: ExprObj, conversion, format_spec):
+        expressions = []
+
+        for idx, expression in enumerate(expr_obj.expressions):
+            if idx == len(expr_obj.expressions) - 1:
+                expressions.append(expression)
+            else:
+                expressions.append("{" + expression + "}")
+
+        return tuple(expressions)

--- a/app/visualize/analysis/stmt/parser/expr/parser/joined_str_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/joined_str_expr.py
@@ -1,0 +1,33 @@
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj, ConstantObj
+from app.visualize.utils import utils
+
+
+class JoinedStrExpr:
+    @staticmethod
+    def parse(value_objs: list[ExprObj]):
+        value = JoinedStrExpr._get_value(value_objs)
+        expressions = JoinedStrExpr._concat_expressions(value_objs, value)
+
+        return ConstantObj(value=value, expressions=expressions)
+
+    @staticmethod
+    def _get_value(value_objs: list[ExprObj]):
+        return "".join(str(value_obj.value) for value_obj in value_objs)
+
+    @staticmethod
+    def _concat_expressions(value_objs: list[ExprObj], value):
+        expressions = []
+
+        transposed_expressions = utils.transpose_with_last_fill([value_obj.expressions for value_obj in value_objs])
+
+        for transposed_expression in transposed_expressions:
+            without_apostrophe = [
+                expression[1:-1] if str(expression).startswith("'") and expression.endswith("'") else expression
+                for expression in transposed_expression
+            ]
+
+            expressions.append("".join(without_apostrophe))
+
+        transposed_expressions.append(value)
+
+        return tuple(expressions)

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_formatted_value_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_formatted_value_expr.py
@@ -1,0 +1,68 @@
+import pytest
+
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import NameObj, BinopObj, ConstantObj, ExprObj
+from app.visualize.analysis.stmt.parser.expr.models.expr_type import ExprType
+from app.visualize.analysis.stmt.parser.expr.parser.formatted_value_expr import FormattedValueExpr
+
+
+@pytest.mark.parametrize(
+    "expr_obj, conversion, format_spec, expected",
+    [
+        pytest.param(
+            ConstantObj(value=10, expressions=("10",)),
+            -1,
+            None,
+            10,
+            id="{a}: success case",
+        ),
+        pytest.param(
+            NameObj(value=10, expressions=("a", "10"), type=ExprType.VARIABLE),
+            -1,
+            None,
+            10,
+            id="{a}: success case",
+        ),
+        pytest.param(
+            BinopObj(value=50, expressions=("x + y", "30 + 20", "50")),
+            -1,
+            None,
+            50,
+            id="{x + y}: success case",
+        ),
+    ],
+)
+def test_get_value(expr_obj: ExprObj, conversion, format_spec, expected):
+    result = FormattedValueExpr._get_value(expr_obj, conversion, format_spec)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "expr_obj, conversion, format_spec, expected",
+    [
+        pytest.param(
+            ConstantObj(value=10, expressions=("10",)),
+            -1,
+            None,
+            ("10",),
+            id="{a}: success case",
+        ),
+        pytest.param(
+            NameObj(value=10, expressions=("a", "10"), type=ExprType.VARIABLE),
+            -1,
+            None,
+            ("{a}", "10"),
+            id="{a}: success case",
+        ),
+        pytest.param(
+            BinopObj(value=50, expressions=("x + y", "30 + 20", "50")),
+            -1,
+            None,
+            ("{x + y}", "{30 + 20}", "50"),
+            id="{x + y}: success case",
+        ),
+    ],
+)
+def test_concat_expression(expr_obj: ExprObj, conversion, format_spec, expected):
+    result = FormattedValueExpr._concat_expressions(expr_obj, conversion, format_spec)
+
+    assert result == expected

--- a/tests/visualize/analysis/stmt/parser/expr/parser/test_joined_str_expr.py
+++ b/tests/visualize/analysis/stmt/parser/expr/parser/test_joined_str_expr.py
@@ -1,0 +1,104 @@
+import pytest
+
+from app.visualize.analysis.stmt.parser.expr.models.expr_obj import ExprObj, ConstantObj, FormattedValueObj
+from app.visualize.analysis.stmt.parser.expr.parser.joined_str_expr import JoinedStrExpr
+
+
+@pytest.mark.parametrize(
+    "value_objs, expected",
+    [
+        pytest.param([], "", id="empty: success case"),
+        pytest.param(
+            [
+                ConstantObj(value="i am ", expressions=("i am",)),
+                FormattedValueObj(
+                    value="song",
+                    expressions=(
+                        "{name}",
+                        "song",
+                    ),
+                ),
+            ],
+            "i am song",
+            id='f"i am {a}", success case',
+        ),
+        pytest.param(
+            [
+                FormattedValueObj(
+                    value="30",
+                    expressions=(
+                        "{x}",
+                        "30",
+                    ),
+                ),
+                ConstantObj(value=" + ", expressions=(" + ",)),
+                FormattedValueObj(
+                    value="20",
+                    expressions=(
+                        "{y}",
+                        "20",
+                    ),
+                ),
+                ConstantObj(value=" = ", expressions=(" = ",)),
+                FormattedValueObj(value="50", expressions=("{x + y}", "{30 + 20}", "50")),
+            ],
+            "30 + 20 = 50",
+            id='f"{x} + {y} = {x + y}", success case',
+        ),
+    ],
+)
+def test_get_value(value_objs: list[ExprObj], expected):
+    result = JoinedStrExpr._get_value(value_objs)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "value_objs, value, expected",
+    [
+        pytest.param([], "", (), id="empty: success case"),
+        pytest.param(
+            [
+                ConstantObj(value="i am ", expressions=("i am ",)),
+                FormattedValueObj(
+                    value="song",
+                    expressions=(
+                        "{name}",
+                        "song",
+                    ),
+                ),
+            ],
+            "i am song",
+            ("i am {name}", "i am song"),
+            id='f"i am {a}", success case',
+        ),
+        pytest.param(
+            [
+                FormattedValueObj(
+                    value="30",
+                    expressions=(
+                        "{x}",
+                        "30",
+                    ),
+                ),
+                ConstantObj(value=" + ", expressions=(" + ",)),
+                FormattedValueObj(
+                    value="20",
+                    expressions=(
+                        "{y}",
+                        "20",
+                    ),
+                ),
+                ConstantObj(value=" = ", expressions=(" = ",)),
+                FormattedValueObj(value="50", expressions=("{x + y}", "{30 + 20}", "50")),
+            ],
+            "30 + 20 = 50",
+            ("{x} + {y} = {x + y}", "30 + 20 = {30 + 20}", "30 + 20 = 50"),
+            id='f"{x} + {y} = {x + y}", success case',
+        ),
+    ],
+)
+def test_concat_expressions(value_objs: list[ExprObj], value, expected):
+    result = JoinedStrExpr._concat_expressions(value_objs, value)
+
+    assert result == expected

--- a/tests/visualize/analysis/stmt/parser/test_while_stmt.py
+++ b/tests/visualize/analysis/stmt/parser/test_while_stmt.py
@@ -12,7 +12,7 @@ from app.visualize.analysis.stmt.parser.while_stmt import WhileStmt
     "test_node, test_obj",
     [
         pytest.param(
-            ast.Compare(left=ast.Num(n=3), ops=[ast.Lt()], comparators=[ast.Num(n=10)]),
+            ast.Compare(left=ast.Constant(3), ops=[ast.Lt()], comparators=[ast.Constant(10)]),
             CompareObj(expressions=("3 < 10", "True"), value=True),
             id="3 < 10: success case",
         ),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #219 

## 📝 작업 내용

- formatted_value_expr 테스트 코드 작성
- joined_str_expr 테스트 코드 작성
- formatted_value_expr 기능 구현
- joined_str_expr 기능 구현

### 스크린샷 (선택)
```
x = 5
y = 10
print(f"{x} * {y} = {x * y}") 
```
```
[
    {
        "id": 2,
        "depth": 1,
        "expr": "5",
        "code": "x = 5",
        "type": "variable"
    },
    {
        "variables": [
            {
                "id": 2,
                "expr": "5",
                "name": "x",
                "code": "x = 5",
                "type": "variable"
            }
        ],
        "type": "assign"
    },
    {
        "id": 3,
        "depth": 1,
        "expr": "10",
        "code": "y = 10",
        "type": "variable"
    },
    {
        "variables": [
            {
                "id": 3,
                "expr": "10",
                "name": "y",
                "code": "y = 10",
                "type": "variable"
            }
        ],
        "type": "assign"
    },
    {
        "id": 4,
        "depth": 1,
        "expr": "{x} * {y} = {x * y}",
        "highlights": [
            0,
            1,
            2,
            3,
            4,
            5,
            6,
            7,
            8,
            9,
            10,
            11,
            12,
            13,
            14,
            15,
            16,
            17,
            18
        ],
        "console": null,
        "code": "print(f\"{x} * {y} = {x * y}\") ",
        "type": "print"
    },
    {
        "id": 4,
        "depth": 1,
        "expr": "5 * 10 = {5 * 10}",
        "highlights": [
            0,
            1,
            2,
            3,
            4,
            5,
            6,
            7,
            8,
            9,
            10,
            11,
            12,
            13,
            14,
            15,
            16
        ],
        "console": null,
        "code": "print(f\"{x} * {y} = {x * y}\") ",
        "type": "print"
    },
    {
        "id": 4,
        "depth": 1,
        "expr": "5 * 10 = 50",
        "highlights": [
            0,
            1,
            2,
            3,
            4,
            5,
            6,
            7,
            8,
            9,
            10
        ],
        "console": "5 * 10 = 50\n",
        "code": "print(f\"{x} * {y} = {x * y}\") ",
        "type": "print"
    }
]
```

## 💬 리뷰 요구사항(선택)

- 지금은 기본적인 값을 대입하거나 표현식을 평가하는 기능만 가능합니다.
- FormattedValueExpr에 있는 conversion과 format_spec은 아래 포멧팅 적용하면서 사용할거라 추가되어있는데 아직 사용하지는 않습니다!
- :.2f와 같이 소수점 포멧팅이나 !s 같이 문자 포멧팅은 추후 추가 예정입니다.
