### PR TITLE
[Feat] a[0] = 'y' 기능 추가

### DIFF
--- a/app/visualize/analysis/stmt/parser/expr/expr_traveler.py
+++ b/app/visualize/analysis/stmt/parser/expr/expr_traveler.py
@@ -136,7 +136,7 @@ class ExprTraveler:
         target_obj = ExprTraveler.travel(node.value, elem_container)
         slice_obj = ExprTraveler.travel(node.slice, elem_container)
 
-        subscript_obj = SubscriptExpr.parse(target_obj, slice_obj)
+        subscript_obj = SubscriptExpr.parse(target_obj, slice_obj, node.ctx)
         return subscript_obj
 
     @staticmethod

--- a/app/visualize/analysis/stmt/parser/expr/parser/subscript_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/subscript_expr.py
@@ -10,7 +10,7 @@ from app.visualize.analysis.stmt.parser.expr.models.expr_obj import (
 class SubscriptExpr:
 
     @staticmethod
-    def parse(target_obj: ExprObj, slice_obj: ExprObj, ctx) -> SubscriptObj:
+    def parse(target_obj: ExprObj, slice_obj: ExprObj, ctx: ast) -> SubscriptObj:
         value = SubscriptExpr._get_value(target_obj.value, slice_obj.value)
         expressions = SubscriptExpr._create_expressions(target_obj, slice_obj)
 

--- a/app/visualize/analysis/stmt/parser/expr/parser/subscript_expr.py
+++ b/app/visualize/analysis/stmt/parser/expr/parser/subscript_expr.py
@@ -1,3 +1,5 @@
+import ast
+
 from app.visualize.analysis.stmt.parser.expr.models.expr_obj import (
     ExprObj,
     SliceObj,
@@ -8,9 +10,12 @@ from app.visualize.analysis.stmt.parser.expr.models.expr_obj import (
 class SubscriptExpr:
 
     @staticmethod
-    def parse(target_obj: ExprObj, slice_obj: ExprObj) -> SubscriptObj:
+    def parse(target_obj: ExprObj, slice_obj: ExprObj, ctx) -> SubscriptObj:
         value = SubscriptExpr._get_value(target_obj.value, slice_obj.value)
         expressions = SubscriptExpr._create_expressions(target_obj, slice_obj)
+
+        if isinstance(ctx, ast.Store):
+            value = expressions[0]
 
         return SubscriptObj(value=value, expressions=expressions)
 

--- a/app/visualize/container/element_container.py
+++ b/app/visualize/container/element_container.py
@@ -33,9 +33,9 @@ class ElementContainer:
         # a[0:1]에서 a 추출
         list_name = name.split("[")[0]
         # a[0:1]에서 0:1 부분 추출
-        sliced_index = name.split("[")[1].split("]")[0]
+        sliced_index = name[name.index("[") + 1 : name.index("]")]
         # 0:1 -> [0, 1]
-        slice_list = [int(x) for x in sliced_index.split(":")]
+        slice_list = list(map(int, sliced_index.split(":")))
 
         # 해당 list를 찾아온다.
         find_list = self.element_dict[list_name]

--- a/app/visualize/container/element_container.py
+++ b/app/visualize/container/element_container.py
@@ -21,6 +21,7 @@ class ElementContainer:
         # 할당해야 하는 target이 리스트 의 특정 인덱스인 경우
         if "[" in name and "]" in name:
             self._set_subscript_target(name, value)
+            return
 
         self.element_dict[name] = value
         return

--- a/app/visualize/container/element_container.py
+++ b/app/visualize/container/element_container.py
@@ -18,8 +18,32 @@ class ElementContainer:
                 self.element_dict[name[i]] = value[i]
             return
 
+        # 할당해야 하는 target이 리스트 의 특정 인덱스인 경우
+        if "[" in name and "]" in name:
+            self._set_subscript_target(name, value)
+
         self.element_dict[name] = value
         return
 
     def get_element_dict(self):
         return self.element_dict
+
+    def _set_subscript_target(self, name, value):
+        # a[0:1]에서 a 추출
+        list_name = name.split("[")[0]
+        # a[0:1]에서 0:1 부분 추출
+        sliced_index = name.split("[")[1].split("]")[0]
+        # 0:1 -> [0, 1]
+        slice_list = [int(x) for x in sliced_index.split(":")]
+
+        # 해당 list를 찾아온다.
+        find_list = self.element_dict[list_name]
+
+        # start, end, step 인 경우
+        if len(slice_list) > 1:
+            find_list[slice(*slice_list)] = value
+            return
+
+        # 값 하나만 바꾸는 경우
+        find_list[int(slice_list[0])] = value
+        return


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #193 

## 📝 작업 내용

- a[0] = 'y'와 같이 이미 저장된 값은 변경이 적용되지 않고 있었다.
- a[0] = 10, a[0:2] = [1, 2]와 같이 slice 형태도 지원하도록 기능을 추가헀다.
- subscript에 테스트케이스를 두가지 추가했다.

### 스크린샷 (선택)
```
a = [1, 2, 3, 4]
a[1:2] = [30]
print(a)
a[2] = 20
print(a)
a[1:3] = ['x', 'y']
print(a)
```
변화과정
[1, 2, 3, 4] => [1, 30, 3, 4] => [1, 30, 20, 4] => [1, 'x', 'y', 4]

## 💬 리뷰 요구사항(선택)

- elem_container에서 "a[0:3]"라는 문자를 타겟으로 받는경우에 로직을 실행시켜서 변경하고 있는데 더 좋은 방식이 있다면 이야기해주세요~
