### PR TITLE
[#265]fix: returnArgName -> returnName

### DIFF
--- a/app/visualize/generator/converter/user_func_converter.py
+++ b/app/visualize/generator/converter/user_func_converter.py
@@ -50,7 +50,7 @@ class UserFuncConverter:
             id=user_func_stmt_obj.id,
             depth=viz_manager.get_depth(),
             returnExpr=user_func_stmt_obj.expr[-1],
-            returnArgName="" if len(targets) == 0 else targets[0],
+            returnName="" if len(targets) == 0 else targets[0],
             code=viz_manager.get_code_by_idx(user_func_stmt_obj.id),
             delFuncName=user_func_stmt_obj.func_name,
         )

--- a/app/visualize/generator/models/user_func_viz.py
+++ b/app/visualize/generator/models/user_func_viz.py
@@ -38,7 +38,7 @@ class EndUserFuncViz:
     id: int
     depth: int
     returnExpr: str
-    returnArgName: str
+    returnName: str
     code: str
     delFuncName: str
     type: str = field(default="endUserFunc", init=False)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #265

## 📝 작업 내용

프론트에서 받는 내용이랑 안맞아서 백엔드 구조 수정함. 기존 retunrArgName보다 프론트에서 사용하는 returnName이 더 직관적인 것 같아서 returnName로 변경
- returnArgName -> returnName

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
